### PR TITLE
Sync with source

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,4 +1,9 @@
 {
   "tool": "Credential Scanner",
-  "suppressions": []
+  "suppressions": [
+    {
+      "file": "src/Bicep.Core.IntegrationTests/Scenarios/ParamKeyVaultSecretReferenceTests.cs",
+      "_justification": "The flagged strings are not secrets. They are part of Key Vault references."
+    }
+  ]
 }

--- a/docs/cicd-with-bicep.md
+++ b/docs/cicd-with-bicep.md
@@ -38,7 +38,7 @@ jobs:
       # Transpile bicep file into ARM template
       - name: Build ARM Template from bicep file
         run: |
-          az bicep build --files ./main.bicep
+          az bicep build --file ./main.bicep
       
       # Stop here if you only want to do "CI" which just generates the 
       # build artifact (ARM Template JSON)
@@ -103,7 +103,7 @@ stages:
           scriptLocation: inlineScript
           inlineScript: |
             az --version
-            az bicep build --files ./main.bicep
+            az bicep build --file ./main.bicep
 
       - task: AzureResourceManagerTemplateDeployment@3
         displayName: 'Validate APIM Templates'

--- a/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
+++ b/src/Bicep.Core.IntegrationTests/TypeSystem/TypeValidationTests.cs
@@ -54,14 +54,14 @@ resource myRes 'My.Rp/myType@2020-01-01' = {
             var customTypes = new [] {
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myType", "2020-01-01", validationFlags,
                     new TypeProperty("readOnlyProp", LanguageConstants.String, TypePropertyFlags.ReadOnly),
-                    new TypeProperty("writeOnlyProp", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                    new TypeProperty("writeOnlyProp", LanguageConstants.String, TypePropertyFlags.WriteOnly | TypePropertyFlags.AllowImplicitNull),
                     new TypeProperty("requiredProp", LanguageConstants.String, TypePropertyFlags.Required),
                     new TypeProperty("additionalProps", new ObjectType(
                         "additionalProps",
                         validationFlags,
                         new [] {
                             new TypeProperty("propA", LanguageConstants.String, TypePropertyFlags.Required),
-                            new TypeProperty("propB", LanguageConstants.String),
+                            new TypeProperty("propB", LanguageConstants.String, TypePropertyFlags.AllowImplicitNull),
                         },
                         LanguageConstants.Int
                     )),
@@ -70,7 +70,7 @@ resource myRes 'My.Rp/myType@2020-01-01' = {
                         validationFlags, 
                         new [] {
                             new TypeProperty("readOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.ReadOnly),
-                            new TypeProperty("writeOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                            new TypeProperty("writeOnlyNestedProp", LanguageConstants.String, TypePropertyFlags.WriteOnly | TypePropertyFlags.AllowImplicitNull),
                             new TypeProperty("requiredNestedProp", LanguageConstants.String, TypePropertyFlags.Required),
                         },
                         null
@@ -104,12 +104,12 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
             model.GetAllDiagnostics().Should().SatisfyRespectively(
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"requiredProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP073", expectedDiagnosticLevel).And.HaveMessage("The property \"readOnlyProp\" is read-only. Expressions cannot be assigned to read-only properties."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"propA\"."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"propB\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"propB\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP035", expectedDiagnosticLevel).And.HaveMessage("The specified \"object\" declaration is missing the following required properties: \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP073", expectedDiagnosticLevel).And.HaveMessage("The property \"readOnlyNestedProp\" is read-only. Expressions cannot be assigned to read-only properties."),
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyNestedProp\" expected a value of type \"string\" but the provided value is of type \"int\"."),
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyNestedProp\" expected a value of type \"null | string\" but the provided value is of type \"int\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP077", expectedDiagnosticLevel).And.HaveMessage("The property \"writeOnlyProp\" on type \"properties\" is write-only. Write-only properties cannot be accessed."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"nestedObj\" does not contain property \"writeOnlyProp\". Available properties include \"readOnlyNestedProp\", \"requiredNestedProp\"."),
                 x => x.Should().HaveCodeAndSeverity("BCP053", expectedDiagnosticLevel).And.HaveMessage("The type \"properties\" does not contain property \"missingOutput\". Available properties include \"additionalProps\", \"nestedObj\", \"readOnlyProp\", \"requiredProp\"."),
@@ -126,16 +126,16 @@ output incorrectTypeOutput2 int = myRes.properties.nestedObj.readOnlyProp
         {
             var customTypes = new [] {
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myType", "2020-01-01", validationFlags,
-                    new TypeProperty("stringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("unspecifiedStringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("abcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"))),
-                    new TypeProperty("unspecifiedAbcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")))),
+                    new TypeProperty("stringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("unspecifiedStringOrInt", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("unspecifiedAbcOrDef", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def")), TypePropertyFlags.AllowImplicitNull)),
                 TestTypeHelper.CreateCustomResourceType("My.Rp/myDependentType", "2020-01-01", validationFlags,
-                    new TypeProperty("stringOnly", LanguageConstants.String),
-                    new TypeProperty("abcOnly", new StringLiteralType("abc")),
-                    new TypeProperty("abcOnlyUnNarrowed", new StringLiteralType("abc")),
-                    new TypeProperty("stringOrIntUnNarrowed", UnionType.Create(LanguageConstants.String, LanguageConstants.Int)),
-                    new TypeProperty("abcOrDefUnNarrowed", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"), new StringLiteralType("ghi")))),
+                    new TypeProperty("stringOnly", LanguageConstants.String, TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOnly", new StringLiteralType("abc"), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOnlyUnNarrowed", new StringLiteralType("abc"), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("stringOrIntUnNarrowed", UnionType.Create(LanguageConstants.String, LanguageConstants.Int), TypePropertyFlags.AllowImplicitNull),
+                    new TypeProperty("abcOrDefUnNarrowed", UnionType.Create(new StringLiteralType("abc"), new StringLiteralType("def"), new StringLiteralType("ghi")), TypePropertyFlags.AllowImplicitNull)),
             };
             var program = @"
 resource myRes 'My.Rp/myType@2020-01-01' = {
@@ -160,7 +160,7 @@ resource myDependentRes 'My.Rp/myDependentType@2020-01-01' = {
 
             var model = GetSemanticModelForTest(program, customTypes);
             model.GetAllDiagnostics().Should().SatisfyRespectively(
-                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"abcOnlyUnNarrowed\" expected a value of type \"'abc'\" but the provided value is of type \"'abc' | 'def'\".")
+                x => x.Should().HaveCodeAndSeverity("BCP036", expectedDiagnosticLevel).And.HaveMessage("The property \"abcOnlyUnNarrowed\" expected a value of type \"'abc' | null\" but the provided value is of type \"'abc' | 'def'\".")
             );
         }
 

--- a/src/Bicep.Core.Samples/Files/Completions/declarations.json
+++ b/src/Bicep.Core.Samples/Files/Completions/declarations.json
@@ -420,12 +420,48 @@
     }
   },
   {
+    "label": "res-cosmos-cassandra-keyspace",
+    "kind": "snippet",
+    "detail": "Cosmos DB Cassandra Namespace",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-cassandra-keyspace",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:cassandraKeyspace} 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {\n      throughput: ${4:'throughput'}\n    }\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-cosmos-cassandra-table",
+    "kind": "snippet",
+    "detail": "Cosmos DB Cassandra Table",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource cassandraKeyspaceTable 'Microsoft.DocumentDb/databaseAccounts/apis/keyspaces/tables@2016-03-31' = {\n  parent: cassandraKeyspace\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-cassandra-table",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {\n  name: ${1:'name'}\n  properties: {\n    resource: {\n      id: ${2:'id'}\n    }\n    options: {}\n  }\n}\n\nresource ${3:cassandraKeyspaceTable} 'Microsoft.DocumentDb/databaseAccounts/apis/keyspaces/tables@2016-03-31' = {\n  parent: cassandraKeyspace\n  name: ${4:'name'}\n  properties: {\n    resource: {\n      id: ${5:'id'}\n    }\n    options: {}\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-cosmos-gremlin-database",
     "kind": "snippet",
     "detail": "Cosmos DB Gremlin Database",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -434,7 +470,7 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource ${1:databaseAccount} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {\n      throughput: ${4:'throughput'}\n    }\n  }\n}\n"
+      "newText": "resource ${1:gremlinDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {\n      throughput: ${4:'throughput'}\n    }\n  }\n}\n"
     }
   },
   {
@@ -443,7 +479,7 @@
     "detail": "Cosmos DB Gremlin Graph",
     "documentation": {
       "kind": "markdown",
-      "value": "```bicep\nresource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\nresource cosmosDBGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {\n  parent: databaseAccount\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'Consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: -1\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+      "value": "```bicep\nresource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\nresource cosmosDbGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {\n  parent: gremlinDb\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'Consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: -1\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
     },
     "deprecated": false,
     "preselect": false,
@@ -452,7 +488,79 @@
     "insertTextMode": "adjustIndentation",
     "textEdit": {
       "range": {},
-      "newText": "resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${1:'name'}\n  properties: {\n    resource: {\n      id: ${2:'id'}\n    }\n    options: {\n      throughput: ${3:'throughput'}\n    }\n  }\n}\n\nresource ${4:cosmosDBGremlinGraph} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {\n  parent: databaseAccount\n  name: ${5:'name'}\n  properties: {\n    resource: {\n      id: ${6:'id'}\n      partitionKey: {\n        paths: [\n          ${7:'paths'}\n        ]\n        kind: '${8|Hash,Range|}'\n      }\n      indexingPolicy: {\n        indexingMode: '${9|Consistent,Lazy,None|}'\n        includedPaths: [\n          {\n            path: ${10:'path'}\n            indexes: [\n              {\n                kind: '${11|Hash,Range,Spatial|}'\n                dataType: '${12|String,Number,Point,Polygon,LineString,MultiPolygon|}'\n                precision: ${13:-1}\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: ${14:'path'}\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: ${15:'throughput'}\n    }\n  }\n}\n"
+      "newText": "resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${1:'name'}\n  properties: {\n    resource: {\n      id: ${2:'id'}\n    }\n    options: {\n      throughput: ${3:'throughput'}\n    }\n  }\n}\n\nresource ${4:cosmosDbGremlinGraph} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {\n  parent: gremlinDb\n  name: ${5:'name'}\n  properties: {\n    resource: {\n      id: ${6:'id'}\n      partitionKey: {\n        paths: [\n          ${7:'paths'}\n        ]\n        kind: '${8|Hash,Range|}'\n      }\n      indexingPolicy: {\n        indexingMode: '${9|Consistent,Lazy,None|}'\n        includedPaths: [\n          {\n            path: ${10:'path'}\n            indexes: [\n              {\n                kind: '${11|Hash,Range,Spatial|}'\n                dataType: '${12|String,Number,Point,Polygon,LineString,MultiPolygon|}'\n                precision: ${13:-1}\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: ${14:'path'}\n          }\n        ]\n      }\n    }\n    options: {\n      throughput: ${15:'throughput'}\n    }\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-cosmos-mongo-database",
+    "kind": "snippet",
+    "detail": "Cosmos DB Mongo Database",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource mongoDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-mongo-database",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:mongoDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {}\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-cosmos-sql-container",
+    "kind": "snippet",
+    "detail": "Cosmos DB SQL Container",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {}\n  }\n}\n\nresource sqlContainerName 'Microsoft.DocumentDb/databaseAccounts/apis/databases/containers@2016-03-31' = {\n  parent: sqlDb \n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n      partitionKey: {\n        paths: [\n          'paths'\n        ]\n        kind: 'Hash'\n      }\n      indexingPolicy: {\n        indexingMode: 'Consistent'\n        includedPaths: [\n          {\n            path: 'path'\n            indexes: [\n              {\n                kind: 'Hash'\n                dataType: 'String'\n                precision: 'precision'\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: 'path'\n          }\n        ]\n      }\n    }\n    options: {}\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-sql-container",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${1:'name'}\n  properties: {\n    resource: {\n      id: ${2:'id'}\n    }\n    options: {}\n  }\n}\n\nresource ${3:sqlContainerName} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/containers@2016-03-31' = {\n  parent: sqlDb \n  name: ${4:'name'}\n  properties: {\n    resource: {\n      id: ${5:'id'}\n      partitionKey: {\n        paths: [\n          ${6:'paths'}\n        ]\n        kind: '${7|Hash,Range|}'\n      }\n      indexingPolicy: {\n        indexingMode: '${8|Consistent,Lazy,None|}'\n        includedPaths: [\n          {\n            path: ${9:'path'}\n            indexes: [\n              {\n                kind: '${10|Hash,Range,Spatial|}'\n                dataType: '${11|String,Number,Point,Polygon,LineString,MultiPolygon|}'\n                precision: ${12:'precision'}\n              }\n            ]\n          }\n        ]\n        excludedPaths: [\n          {\n            path: ${13:'path'}\n          }\n        ]\n      }\n    }\n    options: {}\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-cosmos-sql-database",
+    "kind": "snippet",
+    "detail": "Cosmos DB SQL Database",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-sql-database",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:sqlDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {\n      throughput: ${4:'throughput'}\n    }\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-cosmos-tablestorage-table",
+    "kind": "snippet",
+    "detail": "Cosmos Table Storage",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-31' = {\n  name: 'name'\n  properties: {\n    resource: {\n      id: 'id'\n    }\n    options: {\n      throughput: 'throughput'\n    }\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-cosmos-tablestorage-table",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:cosmosTable} 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-31' = {\n  name: ${2:'name'}\n  properties: {\n    resource: {\n      id: ${3:'id'}\n    }\n    options: {\n      throughput: ${4:'throughput'}\n    }\n  }\n}\n"
     }
   },
   {
@@ -546,6 +654,24 @@
     }
   },
   {
+    "label": "res-log-analytics-solution",
+    "kind": "snippet",
+    "detail": "Log Analytics Solution",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', 'logAnalyticsWorkspace')\n    containedResources: [\n      resourceId('Microsoft.OperationalInsights/workspaces/views', 'logAnalyticsWorkspace', 'logAnalyticsSolution')\n    ]\n  }\n  plan: {\n    name: 'name'\n    product: 'product'\n    publisher: 'publisher'\n    promotionCode: 'promotionCode'\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-log-analytics-solution",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:logAnalyticsSolution} 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', ${3:'logAnalyticsWorkspace'})\n    containedResources: [\n      resourceId('Microsoft.OperationalInsights/workspaces/views', ${3:'logAnalyticsWorkspace'}, ${4:'logAnalyticsSolution'})\n    ]\n  }\n  plan: {\n    name: ${5:'name'}\n    product: ${6:'product'}\n    publisher: ${7:'publisher'}\n    promotionCode: ${8:'promotionCode'}\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-log-analytics-workspace",
     "kind": "snippet",
     "detail": "Log Analytics Workspace",
@@ -618,6 +744,24 @@
     }
   },
   {
+    "label": "res-media",
+    "kind": "snippet",
+    "detail": "Media Services account",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    storageAccounts: [\n      {\n        id: resourceId('Microsoft.Storage/storageAccounts', 'mediaServiceStorageAccount')\n        type: 'Primary'\n      }\n    ]\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-media",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:mediaServices} 'Microsoft.Media/mediaServices@2020-05-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    storageAccounts: [\n      {\n        id: resourceId('Microsoft.Storage/storageAccounts', ${3:'mediaServiceStorageAccount'})\n        type: '${4|Primary,Secondary|}'\n      }\n    ]\n  }\n}\n"
+    }
+  },
+  {
     "label": "res-mysql",
     "kind": "snippet",
     "detail": "MySQL Database",
@@ -633,6 +777,24 @@
     "textEdit": {
       "range": {},
       "newText": "resource ${1:mySQLdb} 'Microsoft.DBforMySQL/servers@2017-12-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    administratorLogin: ${3:'administratorLogin'}\n    administratorLoginPassword: ${4:'administratorLoginPassword'}\n    createMode: ${5|'Default','GeoRestore','PointInTimeRestore','Replica'|}\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-nic",
+    "kind": "snippet",
+    "detail": "Network Interface",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    ipConfigurations: [\n      {\n        name: 'name'\n        properties: {\n          privateIPAllocationMethod: 'Dynamic'\n          subnet: {\n            id: resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetwork', 'subnet')\n          }\n        }\n      }\n    ]\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-nic",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource ${1:networkInterface} 'Microsoft.Network/networkInterfaces@2020-11-01' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    ipConfigurations: [\n      {\n        name: ${3:'name'}\n        properties: {\n          privateIPAllocationMethod: '${4|Dynamic,Static|}'\n          subnet: {\n            id: resourceId('Microsoft.Network/virtualNetworks/subnets', ${5:'virtualNetwork'}, ${6:'subnet'})\n          }\n        }\n      }\n    ]\n  }\n}\n"
     }
   },
   {
@@ -759,6 +921,24 @@
     "textEdit": {
       "range": {},
       "newText": "resource ${1:sharedImageGallery} 'Microsoft.Compute/galleries@2020-09-30' = {\n  name: ${2:'name'}\n  location: resourceGroup().location\n  properties: {\n    description: ${3:'description'}\n  }\n}\n"
+    }
+  },
+  {
+    "label": "res-sql",
+    "kind": "snippet",
+    "detail": "SQL Database",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\nresource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={\n  name: 'name'\n  location: resourceGroup().location\n}\n\nresource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  parent: sqlServer\n  name: 'name'\n  location: resourceGroup().location\n  properties: {\n    collation: 'collation'\n    edition: 'Basic'\n    maxSizeBytes: 'maxSizeBytes'\n    requestedServiceObjectiveName: 'Basic'\n  }\n}\n\n```"
+    },
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_res-sql",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "resource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={\n  name: ${1:'name'}\n  location: resourceGroup().location\n}\n\nresource ${2:sqlServerDatabase} 'Microsoft.Sql/servers/databases@2014-04-01' = {\n  parent: sqlServer\n  name: ${3:'name'}\n  location: resourceGroup().location\n  properties: {\n    collation: ${4:'collation'}\n    edition: '${5|Basic,Business,BusinessCritical,DataWarehouse,Free,GeneralPurpose,Hyperscale,Premium,PremiumRS,Standard,Stretch,System,System2,Web|}'\n    maxSizeBytes: ${6:'maxSizeBytes'}\n    requestedServiceObjectiveName: '${7|Basic,DS100,DS1000,DS1200,DS1500,DS200,DS2000,DS300,DS400,DS500,DS600,DW100,DW1000,DW10000c,DW1000c,DW1200,DW1500,DW15000c,DW1500c,DW200,DW2000,DW2000c,DW2500c,DW300,DW3000,DW30000c,DW3000c,DW400,DW500,DW5000c,DW600,DW6000,DW6000c,DW7500c,ElasticPool,Free,P1,P11,P15,P2,P3,P4,P6,PRS1,PRS2,PRS4,PRS6,S0,S1,S12,S2,S3,S4,S6,S7,S9,System,System0,System1,System2,System2L,System3,System3L,System4,System4L|}'\n  }\n}\n"
     }
   },
   {

--- a/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/IntermediaryVariables_LF/main.diagnostics.bicep
@@ -15,9 +15,9 @@ resource vm 'Microsoft.Compute/virtualMachines@2020-12-01' = {
   name: 'vm'
   location: 'West US'
   properties: vmProperties
-//@[14:26) [BCP036 (Warning)] The property "enabled" expected a value of type "bool" but the provided value in source declaration "vmProperties" is of type "int". |vmProperties|
-//@[14:26) [BCP036 (Warning)] The property "evictionPolicy" expected a value of type "'Deallocate' | 'Delete'" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
-//@[14:26) [BCP036 (Warning)] The property "storageUri" expected a value of type "string" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "enabled" expected a value of type "bool | null" but the provided value in source declaration "vmProperties" is of type "int". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "evictionPolicy" expected a value of type "'Deallocate' | 'Delete' | null" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
+//@[14:26) [BCP036 (Warning)] The property "storageUri" expected a value of type "null | string" but the provided value in source declaration "vmProperties" is of type "bool". |vmProperties|
 //@[14:26) [BCP037 (Warning)] The property "unknownProp" from source declaration "vmProperties" is not allowed on objects of type "BootDiagnostics". No other properties are allowed. |vmProperties|
 }
 
@@ -34,9 +34,9 @@ resource nic 'Microsoft.Network/networkInterfaces@2020-11-01' = {
   name: 'abc'
   properties: {
     ipConfigurations: ipConfigurations
-//@[22:38) [BCP036 (Warning)] The property "id" expected a value of type "string" but the provided value in source declaration "ipConfigurations" is of type "bool". |ipConfigurations|
+//@[22:38) [BCP036 (Warning)] The property "id" expected a value of type "null | string" but the provided value in source declaration "ipConfigurations" is of type "bool". |ipConfigurations|
 //@[22:38) [BCP037 (Warning)] The property "madeUpProperty" from source declaration "ipConfigurations" is not allowed on objects of type "NetworkInterfaceIPConfigurationPropertiesFormat". Permissible properties include "applicationGatewayBackendAddressPools", "applicationSecurityGroups", "loadBalancerBackendAddressPools", "loadBalancerInboundNatRules", "primary", "privateIPAddress", "privateIPAddressVersion", "privateIPAllocationMethod", "publicIPAddress", "virtualNetworkTaps". |ipConfigurations|
-//@[22:38) [BCP036 (Warning)] The property "subnet" expected a value of type "Subnet" but the provided value in source declaration "ipConfigurations" is of type "'hello'". |ipConfigurations|
+//@[22:38) [BCP036 (Warning)] The property "subnet" expected a value of type "Subnet | null" but the provided value in source declaration "ipConfigurations" is of type "'hello'". |ipConfigurations|
   }
 }
 

--- a/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidExpressions_LF/main.syntax.bicep
@@ -63,10 +63,11 @@ var bad = --33
 //@[4:7)  IdentifierSyntax
 //@[4:7)   Identifier |bad|
 //@[8:9)  Assignment |=|
-//@[10:14)  SkippedTriviaSyntax
+//@[10:14)  UnaryOperationSyntax
 //@[10:11)   Minus |-|
-//@[11:12)   Minus |-|
-//@[12:14)   Integer |33|
+//@[11:14)   SkippedTriviaSyntax
+//@[11:12)    Minus |-|
+//@[12:14)    Integer |33|
 //@[14:15) NewLine |\n|
 var bad = 3 * 4 /
 //@[0:17) VariableDeclarationSyntax
@@ -142,8 +143,9 @@ var bad = (null) ? !
 //@[11:15)     NullKeyword |null|
 //@[15:16)    RightParen |)|
 //@[17:18)   Question |?|
-//@[19:20)   SkippedTriviaSyntax
+//@[19:20)   UnaryOperationSyntax
 //@[19:20)    Exclamation |!|
+//@[20:20)    SkippedTriviaSyntax
 //@[20:20)   SkippedTriviaSyntax
 //@[20:20)   SkippedTriviaSyntax
 //@[20:21) NewLine |\n|
@@ -287,15 +289,16 @@ var not = !!!!!!!true
 //@[4:7)  IdentifierSyntax
 //@[4:7)   Identifier |not|
 //@[8:9)  Assignment |=|
-//@[10:21)  SkippedTriviaSyntax
+//@[10:21)  UnaryOperationSyntax
 //@[10:11)   Exclamation |!|
-//@[11:12)   Exclamation |!|
-//@[12:13)   Exclamation |!|
-//@[13:14)   Exclamation |!|
-//@[14:15)   Exclamation |!|
-//@[15:16)   Exclamation |!|
-//@[16:17)   Exclamation |!|
-//@[17:21)   TrueKeyword |true|
+//@[11:21)   SkippedTriviaSyntax
+//@[11:12)    Exclamation |!|
+//@[12:13)    Exclamation |!|
+//@[13:14)    Exclamation |!|
+//@[14:15)    Exclamation |!|
+//@[15:16)    Exclamation |!|
+//@[16:17)    Exclamation |!|
+//@[17:21)    TrueKeyword |true|
 //@[21:23) NewLine |\n\n|
 
 // unary minus chaining will not be supported (to reserve -- in case we need it)
@@ -306,14 +309,15 @@ var minus = ------12
 //@[4:9)  IdentifierSyntax
 //@[4:9)   Identifier |minus|
 //@[10:11)  Assignment |=|
-//@[12:20)  SkippedTriviaSyntax
+//@[12:20)  UnaryOperationSyntax
 //@[12:13)   Minus |-|
-//@[13:14)   Minus |-|
-//@[14:15)   Minus |-|
-//@[15:16)   Minus |-|
-//@[16:17)   Minus |-|
-//@[17:18)   Minus |-|
-//@[18:20)   Integer |12|
+//@[13:20)   SkippedTriviaSyntax
+//@[13:14)    Minus |-|
+//@[14:15)    Minus |-|
+//@[15:16)    Minus |-|
+//@[16:17)    Minus |-|
+//@[17:18)    Minus |-|
+//@[18:20)    Integer |12|
 //@[20:22) NewLine |\n\n|
 
 // unary minus

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAParams.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "arrayParam:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "objParam",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "objParam:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "stringParamA",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "stringParamA:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "stringParamB",
@@ -78,9 +69,6 @@
     "textEdit": {
       "range": {},
       "newText": "stringParamB:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "params",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "params:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scope",
@@ -78,9 +69,6 @@
     "textEdit": {
       "range": {},
       "newText": "scope:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleATopLevelPropertiesMinusName.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "params",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "params:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scope",
@@ -57,9 +51,6 @@
     "textEdit": {
       "range": {},
       "newText": "scope:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionParams.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "arrayParam:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "objParam",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "objParam:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "stringParamA",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "stringParamA:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "stringParamB",
@@ -78,9 +69,6 @@
     "textEdit": {
       "range": {},
       "newText": "stringParamB:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "params",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "params:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scope",
@@ -78,9 +69,6 @@
     "textEdit": {
       "range": {},
       "newText": "scope:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleAWithConditionTopLevelPropertiesMinusName.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "params",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "params:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scope",
@@ -57,9 +51,6 @@
     "textEdit": {
       "range": {},
       "newText": "scope:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleBodyCompletions.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/moduleBodyCompletions.json
@@ -68,6 +68,24 @@
     }
   },
   {
+    "label": "required-properties",
+    "kind": "snippet",
+    "detail": "Required properties",
+    "documentation": {
+      "kind": "markdown",
+      "value": "```bicep\n{\n\tname: \n\tparams: {\n\t\tarrayParam: \n\t\tobjParam: {\n\t\t}\n\t\tstringParamB: \n\t}\n\t\n}\n```"
+    },
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "2_required-properties",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "{\n\tname: $1\n\tparams: {\n\t\tarrayParam: $2\n\t\tobjParam: {\n\t\t}\n\t\tstringParamB: $3\n\t}\n\t$0\n}"
+    }
+  },
+  {
     "label": "{}",
     "kind": "snippet",
     "detail": "{}",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX.json
@@ -1672,6 +1672,20 @@
     }
   },
   {
+    "label": "moduleWithPath",
+    "kind": "module",
+    "detail": "moduleWithPath",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleWithPath",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleWithPath"
+    }
+  },
+  {
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/Completions/symbolsPlusX_if.json
@@ -1672,6 +1672,20 @@
     }
   },
   {
+    "label": "moduleWithPath",
+    "kind": "module",
+    "detail": "moduleWithPath",
+    "deprecated": false,
+    "preselect": false,
+    "sortText": "2_moduleWithPath",
+    "insertTextFormat": "plainText",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "moduleWithPath"
+    }
+  },
+  {
     "label": "moduleWithSelfCycle",
     "kind": "module",
     "detail": "moduleWithSelfCycle",

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -16,6 +16,9 @@ module moduleWithoutPath = {
 
 }
 
+// #completionTest(41) -> moduleBodyCompletions
+module moduleWithPath './moduleb.bicep' =
+
 // missing identifier #completionTest(7) -> empty
 module 
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.bicep
@@ -406,7 +406,7 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
   name: 'hello-${x}'
   params: {
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -554,7 +554,7 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
   params: {
 //@[2:8) [BCP035 (Error)] The specified "object" declaration is missing the following required properties: "arrayParam", "objParam", "stringParamB". |params|
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.diagnostics.bicep
@@ -23,6 +23,10 @@ module moduleWithoutPath = {
 }
 //@[0:1) [BCP007 (Error)] This declaration type is not recognized. Specify a parameter, variable, resource, or output declaration. |}|
 
+// #completionTest(41) -> moduleBodyCompletions
+module moduleWithPath './moduleb.bicep' =
+//@[41:41) [BCP118 (Error)] Expected the "{" character, the "[" character, or the "if" keyword at this location. ||
+
 // missing identifier #completionTest(7) -> empty
 module 
 //@[7:7) [BCP096 (Error)] Expected a module identifier at this location. ||

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.formatted.bicep
@@ -10,6 +10,9 @@ module moduleWithoutPath = {
 
 }
 
+// #completionTest(41) -> moduleBodyCompletions
+module moduleWithPath './moduleb.bicep' =
+
 // missing identifier #completionTest(7) -> empty
 module 
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -20,6 +20,10 @@ module moduleWithoutPath = {
 
 }
 
+// #completionTest(41) -> moduleBodyCompletions
+module moduleWithPath './moduleb.bicep' =
+//@[7:21) Module moduleWithPath. Type: module. Declaration start char: 0, length: 41
+
 // missing identifier #completionTest(7) -> empty
 module 
 //@[7:7) Module <missing>. Type: error. Declaration start char: 0, length: 7

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.symbols.bicep
@@ -553,11 +553,11 @@ module wrongModuleParameterInLoop2 'modulea.bicep' = [for (x,i) in emptyArray:{
 module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in emptyArray: if(true) {
 //@[67:68) Local x. Type: any. Declaration start char: 67, length: 1
 //@[69:70) Local i. Type: int. Declaration start char: 69, length: 1
-//@[7:42) Module paramNameCompletionsInFilteredLoops. Type: module[]. Declaration start char: 0, length: 185
+//@[7:42) Module paramNameCompletionsInFilteredLoops. Type: module[]. Declaration start char: 0, length: 187
   name: 'hello-${x}'
   params: {
     // #completionTest(0,1,2) -> moduleAParams
-
+  
   }
 }]
 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -67,6 +67,19 @@ module moduleWithoutPath = {
 //@[0:1)  RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
+// #completionTest(41) -> moduleBodyCompletions
+//@[47:48) NewLine |\n|
+module moduleWithPath './moduleb.bicep' =
+//@[0:41) ModuleDeclarationSyntax
+//@[0:6)  Identifier |module|
+//@[7:21)  IdentifierSyntax
+//@[7:21)   Identifier |moduleWithPath|
+//@[22:39)  StringSyntax
+//@[22:39)   StringComplete |'./moduleb.bicep'|
+//@[40:41)  Assignment |=|
+//@[41:41)  SkippedTriviaSyntax
+//@[41:43) NewLine |\n\n|
+
 // missing identifier #completionTest(7) -> empty
 //@[49:50) NewLine |\n|
 module 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.syntax.bicep
@@ -2958,14 +2958,14 @@ module wrongModuleParameterInLoop2 'modulea.bicep' = [for (x,i) in emptyArray:{
 //@[2:4) NewLine |\n\n|
 
 module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in emptyArray: if(true) {
-//@[0:185) ModuleDeclarationSyntax
+//@[0:187) ModuleDeclarationSyntax
 //@[0:6)  Identifier |module|
 //@[7:42)  IdentifierSyntax
 //@[7:42)   Identifier |paramNameCompletionsInFilteredLoops|
 //@[43:58)  StringSyntax
 //@[43:58)   StringComplete |'modulea.bicep'|
 //@[59:60)  Assignment |=|
-//@[61:185)  ForSyntax
+//@[61:187)  ForSyntax
 //@[61:62)   LeftSquare |[|
 //@[62:65)   Identifier |for|
 //@[66:71)   ForVariableBlockSyntax
@@ -2983,14 +2983,14 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[75:85)    IdentifierSyntax
 //@[75:85)     Identifier |emptyArray|
 //@[85:86)   Colon |:|
-//@[87:184)   IfConditionSyntax
+//@[87:186)   IfConditionSyntax
 //@[87:89)    Identifier |if|
 //@[89:95)    ParenthesizedExpressionSyntax
 //@[89:90)     LeftParen |(|
 //@[90:94)     BooleanLiteralSyntax
 //@[90:94)      TrueKeyword |true|
 //@[94:95)     RightParen |)|
-//@[96:184)    ObjectSyntax
+//@[96:186)    ObjectSyntax
 //@[96:97)     LeftBrace |{|
 //@[97:98)     NewLine |\n|
   name: 'hello-${x}'
@@ -3006,16 +3006,17 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[18:20)       StringRightPiece |}'|
 //@[20:21)     NewLine |\n|
   params: {
-//@[2:63)     ObjectPropertySyntax
+//@[2:65)     ObjectPropertySyntax
 //@[2:8)      IdentifierSyntax
 //@[2:8)       Identifier |params|
 //@[8:9)      Colon |:|
-//@[10:63)      ObjectSyntax
+//@[10:65)      ObjectSyntax
 //@[10:11)       LeftBrace |{|
 //@[11:12)       NewLine |\n|
     // #completionTest(0,1,2) -> moduleAParams
-//@[46:48)       NewLine |\n\n|
-
+//@[46:47)       NewLine |\n|
+  
+//@[2:3)       NewLine |\n|
   }
 //@[2:3)       RightBrace |}|
 //@[3:4)     NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -49,6 +49,15 @@ module moduleWithoutPath = {
 //@[0:1) RightBrace |}|
 //@[1:3) NewLine |\n\n|
 
+// #completionTest(41) -> moduleBodyCompletions
+//@[47:48) NewLine |\n|
+module moduleWithPath './moduleb.bicep' =
+//@[0:6) Identifier |module|
+//@[7:21) Identifier |moduleWithPath|
+//@[22:39) StringComplete |'./moduleb.bicep'|
+//@[40:41) Assignment |=|
+//@[41:43) NewLine |\n\n|
+
 // missing identifier #completionTest(7) -> empty
 //@[49:50) NewLine |\n|
 module 

--- a/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidModules_LF/main.tokens.bicep
@@ -1926,8 +1926,9 @@ module paramNameCompletionsInFilteredLoops 'modulea.bicep' = [for (x,i) in empty
 //@[10:11) LeftBrace |{|
 //@[11:12) NewLine |\n|
     // #completionTest(0,1,2) -> moduleAParams
-//@[46:48) NewLine |\n\n|
-
+//@[46:47) NewLine |\n|
+  
+//@[2:3) NewLine |\n|
   }
 //@[2:3) RightBrace |}|
 //@[3:4) NewLine |\n|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/description.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/description.json
@@ -15,9 +15,6 @@
     "textEdit": {
       "range": {},
       "newText": "description:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intModifierProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/intModifierProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "allowed:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "default",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "default:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "maxValue",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "maxValue:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "metadata",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "metadata:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "minValue",
@@ -99,9 +87,6 @@
     "textEdit": {
       "range": {},
       "newText": "minValue:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringLengthConstraints.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringLengthConstraints.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "maxLength:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "minLength",
@@ -36,9 +33,6 @@
     "textEdit": {
       "range": {},
       "newText": "minLength:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringModifierProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/Completions/stringModifierProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "allowed:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "default",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "default:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "maxLength",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "maxLength:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "metadata",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "metadata:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "minLength",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "minLength:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "secure",
@@ -120,9 +105,6 @@
     "textEdit": {
       "range": {},
       "newText": "secure:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.bicep
@@ -164,7 +164,7 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.diagnostics.bicep
@@ -277,8 +277,8 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-//@[34:179) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\n  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions\n  default: 2 + 3\n  maxLength: a + 2\n  minLength: foo()\n  allowed: [\n    i\n  ]\n}|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[34:176) [BCP161 (Info)] Parameter modifiers are deprecated and will be removed in a future release. Use decorators instead (see https://aka.ms/BicepSpecParams for examples). |{\n  // #completionTest(10) -> symbolsPlusParamDefaultFunctions\n  default: 2 + 3\n  maxLength: a + 2\n  minLength: foo()\n  allowed: [\n    i\n  ]\n}|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
 //@[13:14) [BCP057 (Error)] The name "a" does not exist in the current context. |a|

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.formatted.bicep
@@ -160,7 +160,7 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.symbols.bicep
@@ -217,8 +217,8 @@ param wrongMetadataSchemaWithDecorator string
 
 // expression in modifier
 param expressionInModifier string {
-//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 179
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
+//@[6:26) Parameter expressionInModifier. Type: string. Declaration start char: 0, length: 176
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
   default: 2 + 3
   maxLength: a + 2
   minLength: foo()

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.syntax.bicep
@@ -1062,17 +1062,17 @@ param wrongMetadataSchemaWithDecorator string
 // expression in modifier
 //@[25:26) NewLine |\n|
 param expressionInModifier string {
-//@[0:179) ParameterDeclarationSyntax
+//@[0:176) ParameterDeclarationSyntax
 //@[0:5)  Identifier |param|
 //@[6:26)  IdentifierSyntax
 //@[6:26)   Identifier |expressionInModifier|
 //@[27:33)  TypeSyntax
 //@[27:33)   Identifier |string|
-//@[34:179)  ObjectSyntax
+//@[34:176)  ObjectSyntax
 //@[34:35)   LeftBrace |{|
 //@[35:36)   NewLine |\n|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
-//@[63:64)   NewLine |\n|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
+//@[60:61)   NewLine |\n|
   default: 2 + 3
 //@[2:16)   ObjectPropertySyntax
 //@[2:9)    IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidParameters_LF/main.tokens.bicep
@@ -687,8 +687,8 @@ param expressionInModifier string {
 //@[27:33) Identifier |string|
 //@[34:35) LeftBrace |{|
 //@[35:36) NewLine |\n|
-  // #completionTest(10,11) -> symbolsPlusParamDefaultFunctions
-//@[63:64) NewLine |\n|
+  // #completionTest(10) -> symbolsPlusParamDefaultFunctions
+//@[60:61) NewLine |\n|
   default: 2 + 3
 //@[2:9) Identifier |default|
 //@[9:10) Colon |:|

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/delegationProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/delegationProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "id:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -57,9 +51,6 @@
     "textEdit": {
       "range": {},
       "newText": "properties:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "arguments:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "azCliVersion",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "azCliVersion:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "cleanupPreference",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "cleanupPreference:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "containerSettings",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "containerSettings:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "environmentVariables",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "environmentVariables:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "forceUpdateTag",
@@ -120,10 +105,7 @@
     "textEdit": {
       "range": {},
       "newText": "forceUpdateTag:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "primaryScriptUri",
@@ -141,10 +123,7 @@
     "textEdit": {
       "range": {},
       "newText": "primaryScriptUri:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "retentionInterval",
@@ -162,10 +141,7 @@
     "textEdit": {
       "range": {},
       "newText": "retentionInterval:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scriptContent",
@@ -183,10 +159,7 @@
     "textEdit": {
       "range": {},
       "newText": "scriptContent:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "storageAccountSettings",
@@ -204,10 +177,7 @@
     "textEdit": {
       "range": {},
       "newText": "storageAccountSettings:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "supportingScriptUris",
@@ -225,10 +195,7 @@
     "textEdit": {
       "range": {},
       "newText": "supportingScriptUris:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "timeout",
@@ -246,9 +213,6 @@
     "textEdit": {
       "range": {},
       "newText": "timeout:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliPropertiesMinusSpecified.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptCliPropertiesMinusSpecified.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "arguments:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "containerSettings",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "containerSettings:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "forceUpdateTag",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "forceUpdateTag:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "primaryScriptUri",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "primaryScriptUri:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scriptContent",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "scriptContent:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "timeout",
@@ -120,9 +105,6 @@
     "textEdit": {
       "range": {},
       "newText": "timeout:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptPSProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "arguments:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "azPowerShellVersion",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "azPowerShellVersion:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "cleanupPreference",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "cleanupPreference:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "containerSettings",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "containerSettings:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "environmentVariables",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "environmentVariables:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "forceUpdateTag",
@@ -120,10 +105,7 @@
     "textEdit": {
       "range": {},
       "newText": "forceUpdateTag:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "primaryScriptUri",
@@ -141,10 +123,7 @@
     "textEdit": {
       "range": {},
       "newText": "primaryScriptUri:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "retentionInterval",
@@ -162,10 +141,7 @@
     "textEdit": {
       "range": {},
       "newText": "retentionInterval:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "scriptContent",
@@ -183,10 +159,7 @@
     "textEdit": {
       "range": {},
       "newText": "scriptContent:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "storageAccountSettings",
@@ -204,10 +177,7 @@
     "textEdit": {
       "range": {},
       "newText": "storageAccountSettings:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "supportingScriptUris",
@@ -225,10 +195,7 @@
     "textEdit": {
       "range": {},
       "newText": "supportingScriptUris:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "timeout",
@@ -246,9 +213,6 @@
     "textEdit": {
       "range": {},
       "newText": "timeout:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/deploymentScriptTopLevel.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "identity",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "identity:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "location",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "location:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "resource",
@@ -149,9 +137,6 @@
     "textEdit": {
       "range": {},
       "newText": "tags:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/discriminatorProperty.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "kind:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "resource",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/environmentVariableProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "secureValue",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "secureValue:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "value",
@@ -57,9 +51,6 @@
     "textEdit": {
       "range": {},
       "newText": "value:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/subnetPropertiesMinusProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/subnetPropertiesMinusProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "id:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -36,9 +33,6 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/symbolsPlusAccount.json
@@ -5395,5 +5395,19 @@
     "commitCharacters": [
       ":"
     ]
+  },
+  {
+    "label": "{}",
+    "kind": "value",
+    "detail": "{}",
+    "deprecated": false,
+    "preselect": true,
+    "sortText": "1_{}",
+    "insertTextFormat": "snippet",
+    "insertTextMode": "adjustIndentation",
+    "textEdit": {
+      "range": {},
+      "newText": "{\n\t$0\n}"
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "extendedLocation",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "extendedLocation:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "identity",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "identity:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "kind",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "kind:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "location",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "location:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "name",
@@ -120,10 +105,7 @@
     "textEdit": {
       "range": {},
       "newText": "name:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -141,10 +123,7 @@
     "textEdit": {
       "range": {},
       "newText": "properties:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "resource",
@@ -212,10 +191,7 @@
     "textEdit": {
       "range": {},
       "newText": "sku:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "tags",
@@ -233,9 +209,6 @@
     "textEdit": {
       "range": {},
       "newText": "tags:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusName.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "extendedLocation",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "extendedLocation:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "identity",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "identity:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "kind",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "kind:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "location",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "location:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -120,10 +105,7 @@
     "textEdit": {
       "range": {},
       "newText": "properties:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "resource",
@@ -191,10 +173,7 @@
     "textEdit": {
       "range": {},
       "newText": "sku:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "tags",
@@ -212,9 +191,6 @@
     "textEdit": {
       "range": {},
       "newText": "tags:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "dependsOn"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "extendedLocation",
@@ -36,10 +33,7 @@
     "textEdit": {
       "range": {},
       "newText": "extendedLocation"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "identity",
@@ -57,10 +51,7 @@
     "textEdit": {
       "range": {},
       "newText": "identity"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "kind",
@@ -78,10 +69,7 @@
     "textEdit": {
       "range": {},
       "newText": "kind"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "location",
@@ -99,10 +87,7 @@
     "textEdit": {
       "range": {},
       "newText": "location"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -120,10 +105,7 @@
     "textEdit": {
       "range": {},
       "newText": "properties"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "resource",
@@ -191,10 +173,7 @@
     "textEdit": {
       "range": {},
       "newText": "sku"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "tags",
@@ -212,9 +191,6 @@
     "textEdit": {
       "range": {},
       "newText": "tags"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/Completions/topLevelPropertiesMinusNameNoColon.json
@@ -108,56 +108,6 @@
     }
   },
   {
-    "label": "resource",
-    "kind": "keyword",
-    "detail": "Resource keyword",
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "plainText",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource"
-    }
-  },
-  {
-    "label": "resource",
-    "kind": "snippet",
-    "detail": "Nested resource with defaults",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  properties: {\n    \n  }\n}\n```"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  properties: {\n    $0\n  }\n}"
-    }
-  },
-  {
-    "label": "resource",
-    "kind": "snippet",
-    "detail": "Nested resource without defaults",
-    "documentation": {
-      "kind": "markdown",
-      "value": "```bicep\nresource Identifier 'Type' = {\n  name: \n  \n}\n\n```"
-    },
-    "deprecated": false,
-    "preselect": false,
-    "sortText": "2_resource",
-    "insertTextFormat": "snippet",
-    "insertTextMode": "adjustIndentation",
-    "textEdit": {
-      "range": {},
-      "newText": "resource ${1:Identifier} '${2:Type}' = {\n  name: $3\n  $0\n}\n"
-    }
-  },
-  {
     "label": "sku",
     "kind": "property",
     "detail": "sku (Required)",

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.bicep
@@ -382,11 +382,11 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -401,6 +401,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -520,7 +522,7 @@ Discriminator value set 1
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -540,7 +542,7 @@ Discriminator value set 1 (conditional)
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -560,7 +562,7 @@ Discriminator value set 1 (loop)
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -580,7 +582,7 @@ Discriminator value set 1 (filtered loop)
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -601,7 +603,7 @@ Discriminator value set 2
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -623,7 +625,7 @@ Discriminator value set 2 (conditional)
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -646,7 +648,7 @@ Discriminator value set 2 (loops)
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -669,7 +671,7 @@ Discriminator value set 2 (filtered loops)
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -1167,12 +1169,12 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
         }]
       }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.diagnostics.bicep
@@ -551,12 +551,12 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "name", "sku". |missingTopLevelProperties|
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
 //@[9:44) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "kind", "location", "sku". |missingTopLevelPropertiesExceptName|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -571,6 +571,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -711,7 +713,7 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -736,7 +738,7 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_if|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -761,7 +763,7 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_for|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -786,7 +788,7 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[9:38) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetOne_for_if|
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azCliVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
@@ -812,7 +814,7 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[9:31) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -840,7 +842,7 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[9:34) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_if|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -869,7 +871,7 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[9:35) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_for|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -898,7 +900,7 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[9:38) [BCP035 (Error)] The specified "resource" declaration is missing the following required properties: "location", "name". |discriminatorKeySetTwo_for_if|
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
 //@[2:12) [BCP035 (Warning)] The specified "object" declaration is missing the following required properties: "azPowerShellVersion", "retentionInterval". |properties|
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
@@ -1553,13 +1555,13 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
 //@[16:19) [BCP142 (Error)] Property value for-expressions cannot be nested. |for|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
 //@[17:20) [BCP142 (Error)] Property value for-expressions cannot be nested. |for|
         }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.formatted.bicep
@@ -376,7 +376,7 @@ resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -390,6 +390,8 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -1114,7 +1116,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
         }]
       }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.symbols.bicep
@@ -472,14 +472,14 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 }]
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[9:34) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 151
+//@[9:34) Resource missingTopLevelProperties. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 153
   // #completionTest(0, 1, 2) -> topLevelProperties
-
+  
 }
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[9:44) Resource missingTopLevelPropertiesExceptName. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 358
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[9:44) Resource missingTopLevelPropertiesExceptName. Type: Microsoft.Storage/storageAccounts@2020-08-01-preview. Declaration start char: 0, length: 305
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
   name: 'me'
   // do not remove whitespace before the closing curly
   // #completionTest(0, 1, 2) -> topLevelPropertiesMinusName
@@ -488,13 +488,15 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 
 // #completionTest(24,25,26,49,65,69,70) -> virtualNetworksResourceTypes
 resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[9:23) Resource unfinishedVnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 468
+//@[9:23) Resource unfinishedVnet. Type: Microsoft.Network/virtualNetworks@2020-06-01. Declaration start char: 0, length: 531
   name: 'v'
   location: 'eastus'
   properties: {
     subnets: [
       {
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
+       
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
         properties: {
           delegations: [
             {
@@ -638,10 +640,10 @@ var discriminatorKeyValueMissingCompletions3_for_if = discriminatorKeyValueMissi
 Discriminator value set 1
 */
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 264
+//@[9:31) Resource discriminatorKeySetOne. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 266
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -662,10 +664,10 @@ var discriminatorKeySetOneCompletions3 = discriminatorKeySetOne.properties[]
 Discriminator value set 1 (conditional)
 */
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
-//@[9:34) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 276
+//@[9:34) Resource discriminatorKeySetOne_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 278
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -687,10 +689,10 @@ Discriminator value set 1 (loop)
 */
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
 //@[95:100) Local thing. Type: any. Declaration start char: 95, length: 5
-//@[9:35) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 288
+//@[9:35) Resource discriminatorKeySetOne_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 290
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -712,10 +714,10 @@ Discriminator value set 1 (filtered loop)
 */
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
 //@[98:103) Local thing. Type: any. Declaration start char: 98, length: 5
-//@[9:38) Resource discriminatorKeySetOne_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 300
+//@[9:38) Resource discriminatorKeySetOne_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 302
   kind: 'AzureCLI'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptCliProperties
     
@@ -737,10 +739,10 @@ var discriminatorKeySetOneCompletions3_for_if = discriminatorKeySetOne_for_if[1]
 Discriminator value set 2
 */
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 270
+//@[9:31) Resource discriminatorKeySetTwo. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 272
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -764,10 +766,10 @@ var discriminatorKeySetTwoCompletionsArrayIndexer2 = discriminatorKeySetTwo['pro
 Discriminator value set 2 (conditional)
 */
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[9:34) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 273
+//@[9:34) Resource discriminatorKeySetTwo_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01. Declaration start char: 0, length: 275
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -793,10 +795,10 @@ Discriminator value set 2 (loops)
 */
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
 //@[94:99) Local thing. Type: any. Declaration start char: 94, length: 5
-//@[9:35) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 293
+//@[9:35) Resource discriminatorKeySetTwo_for. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 295
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -822,10 +824,10 @@ Discriminator value set 2 (filtered loops)
 */
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
 //@[97:102) Local thing. Type: any. Declaration start char: 97, length: 5
-//@[9:38) Resource discriminatorKeySetTwo_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 305
+//@[9:38) Resource discriminatorKeySetTwo_for_if. Type: Microsoft.Resources/deploymentScripts@2020-10-01[]. Declaration start char: 0, length: 307
   kind: 'AzurePowerShell'
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-
+  
   properties: {
     // #completionTest(0,1,2,3,4) -> deploymentScriptPSProperties
     
@@ -1493,7 +1495,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // property loops cannot be nested (even more nesting)
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
 //@[88:95) Local account. Type: any. Declaration start char: 88, length: 7
-//@[9:33) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 720
+//@[9:33) Resource propertyLoopsCannotNest2. Type: Microsoft.Storage/storageAccounts@2019-06-01[]. Declaration start char: 0, length: 687
   name: account.name
   location: account.location
   sku: {
@@ -1502,14 +1504,14 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
   kind: 'StorageV2'
   properties: {
     // #completionTest(17) -> symbolsPlusAccount
-    networkAcls: {
+    networkAcls:  {
       virtualNetworkRules: [for rule in []: {
 //@[32:36) Local rule. Type: any. Declaration start char: 32, length: 4
         // #completionTest(12,15,31) -> symbolsPlusRule
         id: '${account.name}-${account.location}'
         state: [for state in []: {
 //@[20:25) Local state. Type: any. Declaration start char: 20, length: 5
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
           fake: [for something in []: true]
 //@[21:30) Local something. Type: any. Declaration start char: 21, length: 9
         }]

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.syntax.bicep
@@ -2912,36 +2912,37 @@ resource loopForRuntimeCheck4 'Microsoft.Network/dnsZones@2018-05-01' = [for oth
 //@[2:6) NewLine |\r\n\r\n|
 
 resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[0:151) ResourceDeclarationSyntax
+//@[0:153) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |missingTopLevelProperties|
 //@[35:89)  StringSyntax
 //@[35:89)   StringComplete |'Microsoft.Storage/storageAccounts@2020-08-01-preview'|
 //@[90:91)  Assignment |=|
-//@[92:151)  ObjectSyntax
+//@[92:153)  ObjectSyntax
 //@[92:93)   LeftBrace |{|
 //@[93:95)   NewLine |\r\n|
   // #completionTest(0, 1, 2) -> topLevelProperties
-//@[51:55)   NewLine |\r\n\r\n|
-
+//@[51:53)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
 }
 //@[0:1)   RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
 
 resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@2020-08-01-preview' = {
-//@[0:358) ResourceDeclarationSyntax
+//@[0:305) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:44)  IdentifierSyntax
 //@[9:44)   Identifier |missingTopLevelPropertiesExceptName|
 //@[45:99)  StringSyntax
 //@[45:99)   StringComplete |'Microsoft.Storage/storageAccounts@2020-08-01-preview'|
 //@[100:101)  Assignment |=|
-//@[102:358)  ObjectSyntax
+//@[102:305)  ObjectSyntax
 //@[102:103)   LeftBrace |{|
 //@[103:105)   NewLine |\r\n|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
-//@[114:116)   NewLine |\r\n|
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[61:63)   NewLine |\r\n|
   name: 'me'
 //@[2:12)   ObjectPropertySyntax
 //@[2:6)    IdentifierSyntax
@@ -2963,14 +2964,14 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 // #completionTest(24,25,26,49,65,69,70) -> virtualNetworksResourceTypes
 //@[72:74) NewLine |\r\n|
 resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
-//@[0:468) ResourceDeclarationSyntax
+//@[0:531) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:23)  IdentifierSyntax
 //@[9:23)   Identifier |unfinishedVnet|
 //@[24:70)  StringSyntax
 //@[24:70)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[71:72)  Assignment |=|
-//@[73:468)  ObjectSyntax
+//@[73:531)  ObjectSyntax
 //@[73:74)   LeftBrace |{|
 //@[74:76)   NewLine |\r\n|
   name: 'v'
@@ -2990,28 +2991,32 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[12:20)     StringComplete |'eastus'|
 //@[20:22)   NewLine |\r\n|
   properties: {
-//@[2:354)   ObjectPropertySyntax
+//@[2:417)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
 //@[2:12)     Identifier |properties|
 //@[12:13)    Colon |:|
-//@[14:354)    ObjectSyntax
+//@[14:417)    ObjectSyntax
 //@[14:15)     LeftBrace |{|
 //@[15:17)     NewLine |\r\n|
     subnets: [
-//@[4:332)     ObjectPropertySyntax
+//@[4:395)     ObjectPropertySyntax
 //@[4:11)      IdentifierSyntax
 //@[4:11)       Identifier |subnets|
 //@[11:12)      Colon |:|
-//@[13:332)      ArraySyntax
+//@[13:395)      ArraySyntax
 //@[13:14)       LeftSquare |[|
 //@[14:16)       NewLine |\r\n|
       {
-//@[6:309)       ArrayItemSyntax
-//@[6:309)        ObjectSyntax
+//@[6:372)       ArrayItemSyntax
+//@[6:372)        ObjectSyntax
 //@[6:7)         LeftBrace |{|
 //@[7:9)         NewLine |\r\n|
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
 //@[78:80)         NewLine |\r\n|
+       
+//@[7:9)         NewLine |\r\n|
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
+//@[52:54)         NewLine |\r\n|
         properties: {
 //@[8:211)         ObjectPropertySyntax
 //@[8:18)          IdentifierSyntax
@@ -3606,14 +3611,14 @@ Discriminator value set 1
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:264) ResourceDeclarationSyntax
+//@[0:266) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:31)  IdentifierSyntax
 //@[9:31)   Identifier |discriminatorKeySetOne|
 //@[32:82)  StringSyntax
 //@[32:82)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[83:84)  Assignment |=|
-//@[85:264)  ObjectSyntax
+//@[85:266)  ObjectSyntax
 //@[85:86)   LeftBrace |{|
 //@[86:88)   NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3625,8 +3630,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:18)     StringComplete |'AzureCLI'|
 //@[18:20)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:94)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -3712,14 +3718,14 @@ Discriminator value set 1 (conditional)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = if(2==3) {
-//@[0:276) ResourceDeclarationSyntax
+//@[0:278) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |discriminatorKeySetOne_if|
 //@[35:85)  StringSyntax
 //@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[86:87)  Assignment |=|
-//@[88:276)  IfConditionSyntax
+//@[88:278)  IfConditionSyntax
 //@[88:90)   Identifier |if|
 //@[90:96)   ParenthesizedExpressionSyntax
 //@[90:91)    LeftParen |(|
@@ -3730,7 +3736,7 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[94:95)     IntegerLiteralSyntax
 //@[94:95)      Integer |3|
 //@[95:96)    RightParen |)|
-//@[97:276)   ObjectSyntax
+//@[97:278)   ObjectSyntax
 //@[97:98)    LeftBrace |{|
 //@[98:100)    NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3742,8 +3748,9 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:18)      StringComplete |'AzureCLI'|
 //@[18:20)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:94)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -3829,14 +3836,14 @@ Discriminator value set 1 (loop)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: {
-//@[0:288) ResourceDeclarationSyntax
+//@[0:290) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:35)  IdentifierSyntax
 //@[9:35)   Identifier |discriminatorKeySetOne_for|
 //@[36:86)  StringSyntax
 //@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[87:88)  Assignment |=|
-//@[89:288)  ForSyntax
+//@[89:290)  ForSyntax
 //@[89:90)   LeftSquare |[|
 //@[91:94)   Identifier |for|
 //@[95:100)   LocalVariableSyntax
@@ -3847,7 +3854,7 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[104:105)    LeftSquare |[|
 //@[105:106)    RightSquare |]|
 //@[106:107)   Colon |:|
-//@[108:287)   ObjectSyntax
+//@[108:289)   ObjectSyntax
 //@[108:109)    LeftBrace |{|
 //@[109:111)    NewLine |\r\n|
   kind: 'AzureCLI'
@@ -3859,8 +3866,9 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:18)      StringComplete |'AzureCLI'|
 //@[18:20)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:94)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -3968,14 +3976,14 @@ Discriminator value set 1 (filtered loop)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [ for thing in []: if(true) {
-//@[0:300) ResourceDeclarationSyntax
+//@[0:302) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:38)  IdentifierSyntax
 //@[9:38)   Identifier |discriminatorKeySetOne_for_if|
 //@[39:89)  StringSyntax
 //@[39:89)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[90:91)  Assignment |=|
-//@[92:300)  ForSyntax
+//@[92:302)  ForSyntax
 //@[92:93)   LeftSquare |[|
 //@[94:97)   Identifier |for|
 //@[98:103)   LocalVariableSyntax
@@ -3986,14 +3994,14 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[107:108)    LeftSquare |[|
 //@[108:109)    RightSquare |]|
 //@[109:110)   Colon |:|
-//@[111:299)   IfConditionSyntax
+//@[111:301)   IfConditionSyntax
 //@[111:113)    Identifier |if|
 //@[113:119)    ParenthesizedExpressionSyntax
 //@[113:114)     LeftParen |(|
 //@[114:118)     BooleanLiteralSyntax
 //@[114:118)      TrueKeyword |true|
 //@[118:119)     RightParen |)|
-//@[120:299)    ObjectSyntax
+//@[120:301)    ObjectSyntax
 //@[120:121)     LeftBrace |{|
 //@[121:123)     NewLine |\r\n|
   kind: 'AzureCLI'
@@ -4005,8 +4013,9 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:18)       StringComplete |'AzureCLI'|
 //@[18:20)     NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)     NewLine |\r\n\r\n|
-
+//@[55:57)     NewLine |\r\n|
+  
+//@[2:4)     NewLine |\r\n|
   properties: {
 //@[2:94)     ObjectPropertySyntax
 //@[2:12)      IdentifierSyntax
@@ -4115,14 +4124,14 @@ Discriminator value set 2
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:270) ResourceDeclarationSyntax
+//@[0:272) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:31)  IdentifierSyntax
 //@[9:31)   Identifier |discriminatorKeySetTwo|
 //@[32:82)  StringSyntax
 //@[32:82)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[83:84)  Assignment |=|
-//@[85:270)  ObjectSyntax
+//@[85:272)  ObjectSyntax
 //@[85:86)   LeftBrace |{|
 //@[86:88)   NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4134,8 +4143,9 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:25)     StringComplete |'AzurePowerShell'|
 //@[25:27)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:93)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -4243,14 +4253,14 @@ Discriminator value set 2 (conditional)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
-//@[0:273) ResourceDeclarationSyntax
+//@[0:275) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:34)  IdentifierSyntax
 //@[9:34)   Identifier |discriminatorKeySetTwo_if|
 //@[35:85)  StringSyntax
 //@[35:85)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[86:87)  Assignment |=|
-//@[88:273)  ObjectSyntax
+//@[88:275)  ObjectSyntax
 //@[88:89)   LeftBrace |{|
 //@[89:91)   NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4262,8 +4272,9 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:25)     StringComplete |'AzurePowerShell'|
 //@[25:27)   NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)   NewLine |\r\n\r\n|
-
+//@[55:57)   NewLine |\r\n|
+  
+//@[2:4)   NewLine |\r\n|
   properties: {
 //@[2:93)   ObjectPropertySyntax
 //@[2:12)    IdentifierSyntax
@@ -4372,14 +4383,14 @@ Discriminator value set 2 (loops)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: {
-//@[0:293) ResourceDeclarationSyntax
+//@[0:295) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:35)  IdentifierSyntax
 //@[9:35)   Identifier |discriminatorKeySetTwo_for|
 //@[36:86)  StringSyntax
 //@[36:86)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[87:88)  Assignment |=|
-//@[89:293)  ForSyntax
+//@[89:295)  ForSyntax
 //@[89:90)   LeftSquare |[|
 //@[90:93)   Identifier |for|
 //@[94:99)   LocalVariableSyntax
@@ -4390,7 +4401,7 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[103:104)    LeftSquare |[|
 //@[104:105)    RightSquare |]|
 //@[105:106)   Colon |:|
-//@[107:292)   ObjectSyntax
+//@[107:294)   ObjectSyntax
 //@[107:108)    LeftBrace |{|
 //@[108:110)    NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4402,8 +4413,9 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:25)      StringComplete |'AzurePowerShell'|
 //@[25:27)    NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)    NewLine |\r\n\r\n|
-
+//@[55:57)    NewLine |\r\n|
+  
+//@[2:4)    NewLine |\r\n|
   properties: {
 //@[2:93)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
@@ -4533,14 +4545,14 @@ Discriminator value set 2 (filtered loops)
 */
 //@[2:4) NewLine |\r\n|
 resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for thing in []: if(true) {
-//@[0:305) ResourceDeclarationSyntax
+//@[0:307) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:38)  IdentifierSyntax
 //@[9:38)   Identifier |discriminatorKeySetTwo_for_if|
 //@[39:89)  StringSyntax
 //@[39:89)   StringComplete |'Microsoft.Resources/deploymentScripts@2020-10-01'|
 //@[90:91)  Assignment |=|
-//@[92:305)  ForSyntax
+//@[92:307)  ForSyntax
 //@[92:93)   LeftSquare |[|
 //@[93:96)   Identifier |for|
 //@[97:102)   LocalVariableSyntax
@@ -4551,14 +4563,14 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[106:107)    LeftSquare |[|
 //@[107:108)    RightSquare |]|
 //@[108:109)   Colon |:|
-//@[110:304)   IfConditionSyntax
+//@[110:306)   IfConditionSyntax
 //@[110:112)    Identifier |if|
 //@[112:118)    ParenthesizedExpressionSyntax
 //@[112:113)     LeftParen |(|
 //@[113:117)     BooleanLiteralSyntax
 //@[113:117)      TrueKeyword |true|
 //@[117:118)     RightParen |)|
-//@[119:304)    ObjectSyntax
+//@[119:306)    ObjectSyntax
 //@[119:120)     LeftBrace |{|
 //@[120:122)     NewLine |\r\n|
   kind: 'AzurePowerShell'
@@ -4570,8 +4582,9 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:25)       StringComplete |'AzurePowerShell'|
 //@[25:27)     NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59)     NewLine |\r\n\r\n|
-
+//@[55:57)     NewLine |\r\n|
+  
+//@[2:4)     NewLine |\r\n|
   properties: {
 //@[2:93)     ObjectPropertySyntax
 //@[2:12)      IdentifierSyntax
@@ -8498,14 +8511,14 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 // property loops cannot be nested (even more nesting)
 //@[54:56) NewLine |\r\n|
 resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01' = [for account in storageAccounts: {
-//@[0:720) ResourceDeclarationSyntax
+//@[0:687) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:33)  IdentifierSyntax
 //@[9:33)   Identifier |propertyLoopsCannotNest2|
 //@[34:80)  StringSyntax
 //@[34:80)   StringComplete |'Microsoft.Storage/storageAccounts@2019-06-01'|
 //@[81:82)  Assignment |=|
-//@[83:720)  ForSyntax
+//@[83:687)  ForSyntax
 //@[83:84)   LeftSquare |[|
 //@[84:87)   Identifier |for|
 //@[88:95)   LocalVariableSyntax
@@ -8516,7 +8529,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[99:114)    IdentifierSyntax
 //@[99:114)     Identifier |storageAccounts|
 //@[114:115)   Colon |:|
-//@[116:719)   ObjectSyntax
+//@[116:686)   ObjectSyntax
 //@[116:117)    LeftBrace |{|
 //@[117:119)    NewLine |\r\n|
   name: account.name
@@ -8573,29 +8586,29 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[8:19)      StringComplete |'StorageV2'|
 //@[19:21)    NewLine |\r\n|
   properties: {
-//@[2:483)    ObjectPropertySyntax
+//@[2:450)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
 //@[2:12)      Identifier |properties|
 //@[12:13)     Colon |:|
-//@[14:483)     ObjectSyntax
+//@[14:450)     ObjectSyntax
 //@[14:15)      LeftBrace |{|
 //@[15:17)      NewLine |\r\n|
     // #completionTest(17) -> symbolsPlusAccount
 //@[48:50)      NewLine |\r\n|
-    networkAcls: {
-//@[4:411)      ObjectPropertySyntax
+    networkAcls:  {
+//@[4:378)      ObjectPropertySyntax
 //@[4:15)       IdentifierSyntax
 //@[4:15)        Identifier |networkAcls|
 //@[15:16)       Colon |:|
-//@[17:411)       ObjectSyntax
-//@[17:18)        LeftBrace |{|
-//@[18:20)        NewLine |\r\n|
+//@[18:378)       ObjectSyntax
+//@[18:19)        LeftBrace |{|
+//@[19:21)        NewLine |\r\n|
       virtualNetworkRules: [for rule in []: {
-//@[6:384)        ObjectPropertySyntax
+//@[6:350)        ObjectPropertySyntax
 //@[6:25)         IdentifierSyntax
 //@[6:25)          Identifier |virtualNetworkRules|
 //@[25:26)         Colon |:|
-//@[27:384)         ForSyntax
+//@[27:350)         ForSyntax
 //@[27:28)          LeftSquare |[|
 //@[28:31)          Identifier |for|
 //@[32:36)          LocalVariableSyntax
@@ -8606,7 +8619,7 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[40:41)           LeftSquare |[|
 //@[41:42)           RightSquare |]|
 //@[42:43)          Colon |:|
-//@[44:383)          ObjectSyntax
+//@[44:349)          ObjectSyntax
 //@[44:45)           LeftBrace |{|
 //@[45:47)           NewLine |\r\n|
         // #completionTest(12,15,31) -> symbolsPlusRule
@@ -8636,11 +8649,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[47:49)             StringRightPiece |}'|
 //@[49:51)           NewLine |\r\n|
         state: [for state in []: {
-//@[8:219)           ObjectPropertySyntax
+//@[8:185)           ObjectPropertySyntax
 //@[8:13)            IdentifierSyntax
 //@[8:13)             Identifier |state|
 //@[13:14)            Colon |:|
-//@[15:219)            ForSyntax
+//@[15:185)            ForSyntax
 //@[15:16)             LeftSquare |[|
 //@[16:19)             Identifier |for|
 //@[20:25)             LocalVariableSyntax
@@ -8651,11 +8664,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[29:30)              LeftSquare |[|
 //@[30:31)              RightSquare |]|
 //@[31:32)             Colon |:|
-//@[33:218)             ObjectSyntax
+//@[33:184)             ObjectSyntax
 //@[33:34)              LeftBrace |{|
 //@[34:36)              NewLine |\r\n|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
-//@[126:128)              NewLine |\r\n|
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
+//@[92:94)              NewLine |\r\n|
           fake: [for something in []: true]
 //@[10:43)              ObjectPropertySyntax
 //@[10:14)               IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/InvalidResources_CRLF/main.tokens.bicep
@@ -1862,8 +1862,9 @@ resource missingTopLevelProperties 'Microsoft.Storage/storageAccounts@2020-08-01
 //@[92:93) LeftBrace |{|
 //@[93:95) NewLine |\r\n|
   // #completionTest(0, 1, 2) -> topLevelProperties
-//@[51:55) NewLine |\r\n\r\n|
-
+//@[51:53) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
 }
 //@[0:1) RightBrace |}|
 //@[1:5) NewLine |\r\n\r\n|
@@ -1875,8 +1876,8 @@ resource missingTopLevelPropertiesExceptName 'Microsoft.Storage/storageAccounts@
 //@[100:101) Assignment |=|
 //@[102:103) LeftBrace |{|
 //@[103:105) NewLine |\r\n|
-  // #completionTest(0, 1) -> topLevelPropertiesMinusName #completionTest(2) -> topLevelPropertiesMinusNameNoColon
-//@[114:116) NewLine |\r\n|
+  // #completionTest(2) -> topLevelPropertiesMinusNameNoColon
+//@[61:63) NewLine |\r\n|
   name: 'me'
 //@[2:6) Identifier |name|
 //@[6:7) Colon |:|
@@ -1926,6 +1927,10 @@ resource unfinishedVnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 //@[7:9) NewLine |\r\n|
         // #completionTest(0,1,2,3,4,5,6,7) -> subnetPropertiesMinusProperties
 //@[78:80) NewLine |\r\n|
+       
+//@[7:9) NewLine |\r\n|
+        // #completionTest(0,1,2,3,4,5,6,7) -> empty
+//@[52:54) NewLine |\r\n|
         properties: {
 //@[8:18) Identifier |properties|
 //@[18:19) Colon |:|
@@ -2352,8 +2357,9 @@ resource discriminatorKeySetOne 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2429,8 +2435,9 @@ resource discriminatorKeySetOne_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2507,8 +2514,9 @@ resource discriminatorKeySetOne_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2602,8 +2610,9 @@ resource discriminatorKeySetOne_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:18) StringComplete |'AzureCLI'|
 //@[18:20) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2687,8 +2696,9 @@ resource discriminatorKeySetTwo 'Microsoft.Resources/deploymentScripts@2020-10-0
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2771,8 +2781,9 @@ resource discriminatorKeySetTwo_if 'Microsoft.Resources/deploymentScripts@2020-1
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2863,8 +2874,9 @@ resource discriminatorKeySetTwo_for 'Microsoft.Resources/deploymentScripts@2020-
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -2972,8 +2984,9 @@ resource discriminatorKeySetTwo_for_if 'Microsoft.Resources/deploymentScripts@20
 //@[8:25) StringComplete |'AzurePowerShell'|
 //@[25:27) NewLine |\r\n|
   // #completionTest(0,1,2) -> deploymentScriptTopLevel
-//@[55:59) NewLine |\r\n\r\n|
-
+//@[55:57) NewLine |\r\n|
+  
+//@[2:4) NewLine |\r\n|
   properties: {
 //@[2:12) Identifier |properties|
 //@[12:13) Colon |:|
@@ -5523,11 +5536,11 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[15:17) NewLine |\r\n|
     // #completionTest(17) -> symbolsPlusAccount
 //@[48:50) NewLine |\r\n|
-    networkAcls: {
+    networkAcls:  {
 //@[4:15) Identifier |networkAcls|
 //@[15:16) Colon |:|
-//@[17:18) LeftBrace |{|
-//@[18:20) NewLine |\r\n|
+//@[18:19) LeftBrace |{|
+//@[19:21) NewLine |\r\n|
       virtualNetworkRules: [for rule in []: {
 //@[6:25) Identifier |virtualNetworkRules|
 //@[25:26) Colon |:|
@@ -5567,8 +5580,8 @@ resource propertyLoopsCannotNest2 'Microsoft.Storage/storageAccounts@2019-06-01'
 //@[31:32) Colon |:|
 //@[33:34) LeftBrace |{|
 //@[34:36) NewLine |\r\n|
-          // #completionTest(38) -> symbolsPlusAccountRuleStateSomething #completionTest(16,34) -> symbolsPlusAccountRuleState
-//@[126:128) NewLine |\r\n|
+          // #completionTest(38) -> empty #completionTest(16) -> symbolsPlusAccountRuleState
+//@[92:94) NewLine |\r\n|
           fake: [for something in []: true]
 //@[10:14) Identifier |fake|
 //@[14:15) Colon |:|

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/Completions/subnetIdAndProperties.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/Completions/subnetIdAndProperties.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "id:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -36,9 +33,6 @@
     "textEdit": {
       "range": {},
       "newText": "properties:"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/Completions/subnetIdAndPropertiesNoColon.json
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/Completions/subnetIdAndPropertiesNoColon.json
@@ -15,10 +15,7 @@
     "textEdit": {
       "range": {},
       "newText": "id"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   },
   {
     "label": "properties",
@@ -36,9 +33,6 @@
     "textEdit": {
       "range": {},
       "newText": "properties"
-    },
-    "commitCharacters": [
-      ":"
-    ]
+    }
   }
 ]

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.bicep
@@ -306,7 +306,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
@@ -42,7 +42,7 @@ resource withExpressions 'Microsoft.Storage/storageAccounts@2017-10-01' = {
   properties: {
     supportsHttpsTrafficOnly: !false
     accessTier: true ? 'Hot' : 'Cold'
-//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot'" but the provided value is of type "'Cold' | 'Hot'". |true ? 'Hot' : 'Cold'|
+//@[16:37) [BCP036 (Warning)] The property "accessTier" expected a value of type "'Cool' | 'Hot' | null" but the provided value is of type "'Cold' | 'Hot'". |true ? 'Hot' : 'Cold'|
     encryption: {
       keySource: 'Microsoft.Storage'
       services: {

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.diagnostics.bicep
@@ -322,7 +322,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.formatted.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.formatted.bicep
@@ -305,7 +305,9 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.symbols.bicep
@@ -351,12 +351,14 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 // basic nested loop
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
 //@[68:69) Local i. Type: int. Declaration start char: 68, length: 1
-//@[9:13) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 328
+//@[9:13) Resource vnet. Type: Microsoft.Network/virtualNetworks@2020-06-01[]. Declaration start char: 0, length: 345
   name: 'vnet-${i}'
   properties: {
     subnets: [for j in range(0, 4): {
 //@[18:19) Local j. Type: int. Declaration start char: 18, length: 1
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+     
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
       name: 'subnet-${i}-${j}'
     }]
   }

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.syntax.bicep
@@ -2216,14 +2216,14 @@ resource storageResourcesWithIndex 'Microsoft.Storage/storageAccounts@2019-06-01
 // basic nested loop
 //@[20:22) NewLine |\r\n|
 resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0, 3): {
-//@[0:328) ResourceDeclarationSyntax
+//@[0:345) ResourceDeclarationSyntax
 //@[0:8)  Identifier |resource|
 //@[9:13)  IdentifierSyntax
 //@[9:13)   Identifier |vnet|
 //@[14:60)  StringSyntax
 //@[14:60)   StringComplete |'Microsoft.Network/virtualNetworks@2020-06-01'|
 //@[61:62)  Assignment |=|
-//@[63:328)  ForSyntax
+//@[63:345)  ForSyntax
 //@[63:64)   LeftSquare |[|
 //@[64:67)   Identifier |for|
 //@[68:69)   LocalVariableSyntax
@@ -2243,7 +2243,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[82:83)      Integer |3|
 //@[83:84)    RightParen |)|
 //@[84:85)   Colon |:|
-//@[86:327)   ObjectSyntax
+//@[86:344)   ObjectSyntax
 //@[86:87)    LeftBrace |{|
 //@[87:89)    NewLine |\r\n|
   name: 'vnet-${i}'
@@ -2259,19 +2259,19 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[17:19)      StringRightPiece |}'|
 //@[19:21)    NewLine |\r\n|
   properties: {
-//@[2:214)    ObjectPropertySyntax
+//@[2:231)    ObjectPropertySyntax
 //@[2:12)     IdentifierSyntax
 //@[2:12)      Identifier |properties|
 //@[12:13)     Colon |:|
-//@[14:214)     ObjectSyntax
+//@[14:231)     ObjectSyntax
 //@[14:15)      LeftBrace |{|
 //@[15:17)      NewLine |\r\n|
     subnets: [for j in range(0, 4): {
-//@[4:192)      ObjectPropertySyntax
+//@[4:209)      ObjectPropertySyntax
 //@[4:11)       IdentifierSyntax
 //@[4:11)        Identifier |subnets|
 //@[11:12)       Colon |:|
-//@[13:192)       ForSyntax
+//@[13:209)       ForSyntax
 //@[13:14)        LeftSquare |[|
 //@[14:17)        Identifier |for|
 //@[18:19)        LocalVariableSyntax
@@ -2291,11 +2291,15 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[32:33)           Integer |4|
 //@[33:34)         RightParen |)|
 //@[34:35)        Colon |:|
-//@[36:191)        ObjectSyntax
+//@[36:208)        ObjectSyntax
 //@[36:37)         LeftBrace |{|
 //@[37:39)         NewLine |\r\n|
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[113:115)         NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+//@[62:64)         NewLine |\r\n|
+     
+//@[5:7)         NewLine |\r\n|
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
+//@[59:61)         NewLine |\r\n|
       name: 'subnet-${i}-${j}'
 //@[6:30)         ObjectPropertySyntax
 //@[6:10)          IdentifierSyntax

--- a/src/Bicep.Core.Samples/Files/Resources_CRLF/main.tokens.bicep
+++ b/src/Bicep.Core.Samples/Files/Resources_CRLF/main.tokens.bicep
@@ -1465,8 +1465,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = [for i in range(0
 //@[34:35) Colon |:|
 //@[36:37) LeftBrace |{|
 //@[37:39) NewLine |\r\n|
-      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties #completionTest(6) -> subnetIdAndPropertiesNoColon
-//@[113:115) NewLine |\r\n|
+      // #completionTest(0,1,2,3,4,5) -> subnetIdAndProperties
+//@[62:64) NewLine |\r\n|
+     
+//@[5:7) NewLine |\r\n|
+      // #completionTest(6) -> subnetIdAndPropertiesNoColon
+//@[59:61) NewLine |\r\n|
       name: 'subnet-${i}-${j}'
 //@[6:10) Identifier |name|
 //@[10:11) Colon |:|

--- a/src/Bicep.Core/Extensions/IPositionableExtensions.cs
+++ b/src/Bicep.Core/Extensions/IPositionableExtensions.cs
@@ -8,9 +8,18 @@ namespace Bicep.Core.Extensions
     public static class IPositionableExtensions
     {
         public static TextSpan ToZeroLengthSpan(this IPositionable positionable)
-            => new TextSpan(positionable.Span.Position, 0);
+            => new(positionable.Span.Position, 0);
+
+        public static int GetPosition(this IPositionable positionable)
+            => positionable.Span.Position;
 
         public static int GetEndPosition(this IPositionable positionable)
             => positionable.Span.Position + positionable.Span.Length;
+
+        public static bool IsOverlapping(this IPositionable positionable, int position)
+            => positionable.GetPosition() <= position && position <= positionable.GetEndPosition();
+
+        public static bool IsEnclosing(this IPositionable positionable, int position)
+            => positionable.GetPosition() < position && position < positionable.GetEndPosition();
     }
 }

--- a/src/Bicep.Core/Parsing/Parser.cs
+++ b/src/Bicep.Core/Parsing/Parser.cs
@@ -452,7 +452,15 @@ namespace Bicep.Core.Parsing
             {
                 this.reader.Read();
 
-                var expression = this.MemberExpression(expressionFlags);
+                var expression = this.WithRecovery(
+                    () => this.MemberExpression(expressionFlags),
+                    RecoveryFlags.None,
+                    TokenType.StringRightPiece,
+                    TokenType.RightBrace,
+                    TokenType.RightParen,
+                    TokenType.RightSquare,
+                    TokenType.NewLine);
+
                 return new UnaryOperationSyntax(operatorToken, expression);
             }
 

--- a/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
+++ b/src/Bicep.Core/TypeSystem/Az/AzResourceTypeFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
 using System.Linq;
@@ -61,6 +61,11 @@ namespace Bicep.Core.TypeSystem.Az
             if (input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.DeployTimeConstant))
             {
                 flags |= TypePropertyFlags.DeployTimeConstant;
+            }
+            if(!input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.Required) && !input.Flags.HasFlag(Azure.Bicep.Types.Concrete.ObjectPropertyFlags.ReadOnly))
+            {
+                // for non-required and non-readonly resource properties, we allow null assignment
+                flags |= TypePropertyFlags.AllowImplicitNull;
             }
 
             return flags;

--- a/src/Bicep.Core/TypeSystem/TypePropertyFlags.cs
+++ b/src/Bicep.Core/TypeSystem/TypePropertyFlags.cs
@@ -51,6 +51,12 @@ namespace Bicep.Core.TypeSystem
         /// The property must be loop-variant. In other words, the value of the property must change
         /// based on the value of the loop item or index variables. This flag has no effect outside of top-level properties.
         /// </summary>
-        LoopVariant = 1 << 7
+        LoopVariant = 1 << 7,
+
+        /// <summary>
+        /// On non-required properties, this allows the property type to be treated as "<x> | null" (where <x> is the current property type)
+        /// for the purposes of type checking the value assigned to the property.
+        /// </summary>
+        AllowImplicitNull = 1 << 8
     }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/101-1vm-2nics-2subnets-1vnet/azuredeploy.bicep
@@ -41,7 +41,7 @@ resource virtualMachineName 'Microsoft.Compute/virtualMachines@2019-12-01' = {
       adminPassword: adminPassword
       windowsConfiguration: {
         provisionVMAgent: 'true'
-//@[26:32) [BCP036 (Warning)] The property "provisionVMAgent" expected a value of type "bool" but the provided value is of type "'true'". |'true'|
+//@[26:32) [BCP036 (Warning)] The property "provisionVMAgent" expected a value of type "bool | null" but the provided value is of type "'true'". |'true'|
       }
     }
     hardwareProfile: {

--- a/src/Bicep.Decompiler.IntegrationTests/Working/conditional/nested_deployFlowLogs.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/conditional/nested_deployFlowLogs.bicep
@@ -20,7 +20,7 @@ resource NetworkWatcherName_FlowLogName 'Microsoft.Network/networkWatchers/flowL
     format: {
       type: 'JSON'
       version: FlowLogsversion
-//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int" but the provided value is of type "string". |FlowLogsversion|
+//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int | null" but the provided value is of type "string". |FlowLogsversion|
     }
   }
 }

--- a/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
+++ b/src/Bicep.Decompiler.IntegrationTests/Working/nestedtemplate/nested_deployFlowLogs.bicep
@@ -20,7 +20,7 @@ resource NetworkWatcherName_FlowLogName 'Microsoft.Network/networkWatchers/flowL
     format: {
       type: 'JSON'
       version: FlowLogsversion
-//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int" but the provided value is of type "string". |FlowLogsversion|
+//@[15:30) [BCP036 (Warning)] The property "version" expected a value of type "int | null" but the provided value is of type "string". |FlowLogsversion|
     }
   }
 }

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -247,7 +247,7 @@ var test2 = /|* block c|omment *|/
         [TestMethod]
         public async Task VerifyResourceBodyCompletionWithExistingKeywordDoesNotIncludeCustomSnippet()
         {
-            string text = @"resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' existing = ";
+            string text = "resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' existing = ";
 
             var syntaxTree = SyntaxTree.Create(new Uri("file:///main.bicep"), text);
             using var client = await IntegrationTestHelper.StartServerWithTextAsync(text, syntaxTree.FileUri, resourceTypeProvider: TypeProvider);
@@ -523,6 +523,92 @@ resource testRes3 'Test.Rp/readWriteTests@2020-01-01' = {
                 completions.Should().SatisfyRespectively(
                     l => AssertPropertyNameCompletionsWithoutColons(l!),
                     l => AssertPropertyNameCompletionsWithoutColons(l!)));
+        }
+
+        [TestMethod]
+        public async Task RequestCompletionsInResourceBodies_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {|
+ | name: 'myRes' |
+  tags | : {
+    a: 'A'   |
+  }
+|}
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
+        public async Task RequestCompletionsInProgram_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+|  var obj = {} |
+
+|  resource myRes 'Test.Rp/readWriteTests@2020-01-01' = {
+  name: 'myRes'
+}
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
+        public async Task RequestCompletionsInObjects_AtPositionsWhereNodeShouldNotBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+var obj1 = {|}
+var obj2 = {| }
+var obj3 = |{ |}
+var obj4 = { | }|
+var obj5 = {|
+  | prop: true |
+|}
+var obj6 = { |
+  prop  | : false
+ |  }
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
+        public async Task RequestCompletionsInArrays_AtPositionsWhereNodeShouldBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+var arr1 = [|]
+var arr2 = [| ]
+var arr3 = [ |]|
+var arr4 = |[ | ]
+var arr5 = [|
+  | null |
+|]
+var arr6 = [ |
+  12345
+  |  true
+| ]
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
+        public async Task RequestCompletionsInExpressions_AtPositionsWhereNodeShouldBeInserted_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+var unary = |! | true
+var binary = -1 | |+| | 2
+var ternary = true | |?| | 'yes' | |:| | 'no'
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
+        }
+
+        [TestMethod]
+        public async Task RequestCompletions_MatchingNodeIsBooleanOrIntegerOrNullLiteral_ReturnsEmptyCompletions()
+        {
+            var fileWithCursors = @"
+var booleanExp = !|tr|ue| && |fal|se|
+var integerExp = |12|345| + |543|21|
+var nullLit = |n|ull|
+";
+            await RunCompletionScenarioTest(fileWithCursors, AssertAllCompletionsEmpty);
         }
 
         private static async Task RunCompletionScenarioTest(string fileWithCursors, Action<IEnumerable<CompletionList?>> assertAction)

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -356,10 +356,10 @@ var test2 = /|* block c|omment *|/
                     c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
-	kind: $3
+	kind: 'AzureCLI'
 	properties: {
-		azCliVersion: $4
-		retentionInterval: $5
+		azCliVersion: $3
+		retentionInterval: $4
 	}
 	$0
 }");
@@ -372,10 +372,10 @@ var test2 = /|* block c|omment *|/
                     c.TextEdit?.NewText?.Should().BeEquivalentToIgnoringNewlines(@"{
 	name: $1
 	location: $2
-	kind: $3
+	kind: 'AzurePowerShell'
 	properties: {
-		azPowerShellVersion: $4
-		retentionInterval: $5
+		azPowerShellVersion: $3
+		retentionInterval: $4
 	}
 	$0
 }");

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.bicep
@@ -1,0 +1,6 @@
+﻿// $1 = cassandraKeyspace
+// $2 = 'accountName/cassandra/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-keyspace/main.combined.bicep
@@ -1,0 +1,12 @@
+resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
+  name: 'accountName/cassandra/databaseName'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {
+      throughput: 'throughput'
+    }
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.bicep
@@ -1,0 +1,7 @@
+﻿// $1 = 'accountName/cassandra/databaseName'
+// $2 = 'id'
+// $3 = cassandraKeyspaceTable
+// $4 = 'name'
+// $5 = 'id'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-cassandra-table/main.combined.bicep
@@ -1,0 +1,21 @@
+resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
+  name: 'accountName/cassandra/databaseName'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {}
+  }
+}
+
+resource cassandraKeyspaceTable 'Microsoft.DocumentDb/databaseAccounts/apis/keyspaces/tables@2016-03-31' = {
+  parent: cassandraKeyspace
+  name: 'name'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {}
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.bicep
@@ -1,4 +1,4 @@
-﻿// $1 = databaseAccount
+﻿// $1 = gremlinDb
 // $2 = 'accountName/gremlin/databaseName'
 // $3 = 'id'
 // $4 = 'throughput'

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-gremlin-database/main.combined.bicep
@@ -1,4 +1,4 @@
-resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: 'accountName/gremlin/databaseName'
   properties: {
     resource: {

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.bicep
@@ -1,0 +1,5 @@
+﻿// $1 = mongoDb
+// $2 = 'accountName/mongodb/databaseName'
+// $3 = 'id'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-mongo-database/main.combined.bicep
@@ -1,0 +1,10 @@
+resource mongoDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+  name: 'accountName/mongodb/databaseName'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {}
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.bicep
@@ -1,0 +1,15 @@
+﻿// $1 = 'accountName/sql/databaseName'
+// $2 = 'id'
+// $3 = sqlContainerName
+// $4 = 'name'
+// $5 = 'id'
+// $6 = 'paths'
+// $7 = Hash
+// $8 = Consistent
+// $9 = 'path'
+// $10 = Hash
+// $11 = String
+// $12 = -1
+// $13 = 'path'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-container/main.combined.bicep
@@ -1,17 +1,15 @@
-resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
-  name: 'accountName/gremlin/databaseName'
+resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+  name: 'accountName/sql/databaseName'
   properties: {
     resource: {
       id: 'id'
     }
-    options: {
-      throughput: 'throughput'
-    }
+    options: {}
   }
 }
 
-resource cosmosDBGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {
-  parent: gremlinDb
+resource sqlContainerName 'Microsoft.DocumentDb/databaseAccounts/apis/databases/containers@2016-03-31' = {
+  parent: sqlDb 
   name: 'name'
   properties: {
     resource: {
@@ -43,9 +41,7 @@ resource cosmosDBGremlinGraph 'Microsoft.DocumentDb/databaseAccounts/apis/databa
         ]
       }
     }
-    options: {
-      throughput: 'throughput'
-    }
+    options: {}
   }
 }
 

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.bicep
@@ -1,0 +1,6 @@
+﻿// $1 = sqlDb
+// $2 = 'accountName/sql/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-sql-database/main.combined.bicep
@@ -1,0 +1,12 @@
+resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+  name: 'accountName/sql/databaseName'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {
+      throughput: 'throughput'
+    }
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.bicep
@@ -1,0 +1,6 @@
+﻿// $1 = cosmosTable
+// $2 = 'accountName/table/databaseName'
+// $3 = 'id'
+// $4 = 'throughput'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-cosmos-tablestorage-table/main.combined.bicep
@@ -1,0 +1,12 @@
+resource cosmosTable 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-31' = {
+  name: 'accountName/table/databaseName'
+  properties: {
+    resource: {
+      id: 'id'
+    }
+    options: {
+      throughput: 'throughput'
+    }
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.bicep
@@ -1,0 +1,10 @@
+﻿// $1 = logAnalyticsSolution
+// $2 = 'name'
+// $3 = 'logAnalyticsWorkspace'
+// $4 = 'logAnalyticsSolution'
+// $5 = 'name'
+// $6 = 'product'
+// $7 = 'publisher'
+// $8 = 'promotionCode'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-log-analytics-solution/main.combined.bicep
@@ -1,0 +1,17 @@
+resource logAnalyticsSolution 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
+  name: 'name'
+  location: resourceGroup().location
+  properties: {
+    workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', 'logAnalyticsWorkspace')
+    containedResources: [
+      resourceId('Microsoft.OperationalInsights/workspaces/views', 'logAnalyticsWorkspace', 'logAnalyticsSolution')
+    ]
+  }
+  plan: {
+    name: 'name'
+    product: 'product'
+    publisher: 'publisher'
+    promotionCode: 'promotionCode'
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.bicep
@@ -1,0 +1,6 @@
+﻿// $1 = mediaServices
+// $2 = 'name'
+// $3 = 'mediaServiceStorageAccount'
+// $4 = Primary
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-media/main.combined.bicep
@@ -1,0 +1,13 @@
+resource mediaServices 'Microsoft.Media/mediaServices@2020-05-01' = {
+  name: 'name'
+  location: resourceGroup().location
+  properties: {
+    storageAccounts: [
+      {
+        id: resourceId('Microsoft.Storage/storageAccounts', 'mediaServiceStorageAccount')
+        type: 'Primary'
+      }
+    ]
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.bicep
@@ -1,0 +1,8 @@
+﻿// $1 = networkInterface
+// $2 = 'name'
+// $3 = 'name'
+// $4 = Dynamic
+// $5 = 'virtualNetwork'
+// $6 = 'subnet'
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-nic/main.combined.bicep
@@ -1,0 +1,18 @@
+resource networkInterface 'Microsoft.Network/networkInterfaces@2020-11-01' = {
+  name: 'name'
+  location: resourceGroup().location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'name'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', 'virtualNetwork', 'subnet')
+          }
+        }
+      }
+    ]
+  }
+}
+

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.bicep
@@ -1,0 +1,9 @@
+﻿// $1 = 'name'
+// $2 = sqlServerDatabase
+// $3 = 'name'
+// $4 = 'collation'
+// $5 = Basic
+// $6 = 'maxSizeBytes'
+// $7 = Basic
+
+// Insert snippet here

--- a/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
+++ b/src/Bicep.LangServer.IntegrationTests/Completions/SnippetTemplates/res-sql/main.combined.bicep
@@ -1,0 +1,17 @@
+resource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={
+  name: 'name'
+  location: resourceGroup().location
+}
+
+resource sqlServerDatabase 'Microsoft.Sql/servers/databases@2014-04-01' = {
+  parent: sqlServer
+  name: 'name'
+  location: resourceGroup().location
+  properties: {
+    collation: 'collation'
+    edition: 'Basic'
+    maxSizeBytes: 'maxSizeBytes'
+    requestedServiceObjectiveName: 'Basic'
+  }
+}
+

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -415,6 +415,65 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                 });
         }
 
+        [TestMethod]
+        public void GetModuleBodyCompletionSnippets_WithNoRequiredProperties_ShouldReturnEmptySnippet()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            var objectType = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.ReadOnly),
+                new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.WriteOnly),
+                new TypeProperty("id", LanguageConstants.String)
+            }, null);
+            TypeSymbol typeSymbol = new ModuleType("module", ResourceScope.Module, objectType);
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetModuleBodyCompletionSnippets(typeSymbol);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                });
+        }
+
+        [TestMethod]
+        public void GetModuleBodyCompletionSnippets_WithRequiredProperties_ShouldReturnEmptyAndRequiredPropertiesSnippets()
+        {
+            SnippetsProvider snippetsProvider = new SnippetsProvider();
+            var objectType = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
+            {
+                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("id", LanguageConstants.String)
+            }, null);
+            TypeSymbol typeSymbol = new ModuleType("module", ResourceScope.Module, objectType);
+
+            IEnumerable<Snippet> snippets = snippetsProvider.GetModuleBodyCompletionSnippets(typeSymbol);
+
+            snippets.Should().SatisfyRespectively(
+                x =>
+                {
+                    x.Prefix.Should().Be("{}");
+                    x.Detail.Should().Be("{}");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().Be("{\n\t$0\n}");
+                },
+                x =>
+                {
+                    x.Prefix.Should().Be("required-properties");
+                    x.Detail.Should().Be("Required properties");
+                    x.CompletionPriority.Should().Be(CompletionPriority.Medium);
+                    x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
+	name: $1
+	location: $2
+	$0
+}");
+                });
+        }
+
         private static ObjectType CreateObjectType(string name, params (string name, ITypeReference type, TypePropertyFlags typePropertyFlags)[] properties)
             => new(
                 name,

--- a/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
+++ b/src/Bicep.LangServer.UnitTests/Snippets/SnippetsProviderTests.cs
@@ -362,7 +362,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             var objectTypeA = new ObjectType("objA", TypeSymbolValidationFlags.Default, new[]
             {
                 new TypeProperty("discKey", new StringLiteralType("keyA")),
-                new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
+                new TypeProperty("name", new StringLiteralType("keyA"), TypePropertyFlags.Required),
                 new TypeProperty("location", LanguageConstants.String, TypePropertyFlags.Required),
                 new TypeProperty("id", LanguageConstants.String)
             }, null);
@@ -371,7 +371,7 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
             {
                 new TypeProperty("discKey", new StringLiteralType("keyB")),
                 new TypeProperty("name", LanguageConstants.String, TypePropertyFlags.Required),
-                new TypeProperty("kind", LanguageConstants.String, TypePropertyFlags.ReadOnly),
+                new TypeProperty("kind", new StringLiteralType("discKey"), TypePropertyFlags.ReadOnly),
                 new TypeProperty("hostPoolType", LanguageConstants.String)
             }, null);
 
@@ -398,8 +398,8 @@ resource automationAccount 'Microsoft.Automation/automationAccounts@2015-10-31' 
                     x.Detail.Should().Be("Required properties");
                     x.CompletionPriority.Should().Be(CompletionPriority.Medium);
                     x.Text.Should().BeEquivalentToIgnoringNewlines(@"{
-	name: $1
-	location: $2
+	name: 'keyA'
+	location: $1
 	$0
 }");
                 },

--- a/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionContext.cs
@@ -114,12 +114,12 @@ namespace Bicep.LanguageServer.Completions
                        ConvertFlag(IsNestedResourceStartContext(matchingNodes, topLevelDeclarationInfo, objectInfo, offset), BicepCompletionContextKind.NestedResourceDeclarationStart) |
                        GetDeclarationTypeFlags(matchingNodes, offset) |
                        ConvertFlag(IsResourceTypeFollowerContext(matchingNodes, offset), BicepCompletionContextKind.ResourceTypeFollower) |
-                       GetObjectPropertyNameFlags(matchingNodes, objectInfo) |
+                       GetObjectPropertyNameFlags(matchingNodes, objectInfo, offset) |
                        ConvertFlag(IsMemberAccessContext(matchingNodes, propertyAccessInfo, offset), BicepCompletionContextKind.MemberAccess) |
                        ConvertFlag(IsResourceAccessContext(matchingNodes, resourceAccessInfo, offset), BicepCompletionContextKind.ResourceAccess) |
                        ConvertFlag(IsArrayIndexContext(matchingNodes, arrayAccessInfo), BicepCompletionContextKind.ArrayIndex | BicepCompletionContextKind.Expression) |
                        GetPropertyValueFlags(matchingNodes, propertyInfo, offset) |
-                       ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
+                       ConvertFlag(IsArrayItemContext(matchingNodes, arrayInfo, offset), BicepCompletionContextKind.ArrayItem | BicepCompletionContextKind.Expression) |
                        ConvertFlag(IsResourceBodyContext(matchingNodes, offset), BicepCompletionContextKind.ResourceBody) |
                        ConvertFlag(IsModuleBodyContext(matchingNodes, offset), BicepCompletionContextKind.ModuleBody) |
                        ConvertFlag(IsParameterDefaultValueContext(matchingNodes, offset), BicepCompletionContextKind.ParameterDefaultValue | BicepCompletionContextKind.Expression) |
@@ -254,13 +254,13 @@ namespace Bicep.LanguageServer.Completions
 
                 switch (node)
                 {
-                    case ProgramSyntax _:
+                    case ProgramSyntax programSyntax:
                         // the token at current position is inside a program node
                         // we're in a declaration if one of the following conditions is met:
                         // 1. the token is EOF
-                        // 2. the token is a newline
+                        // 2. the token is a newline and we can insert at the offset
                         return token.Type == TokenType.EndOfFile ||
-                               token.Type == TokenType.NewLine;
+                               (token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset(programSyntax, offset));
 
                     case SkippedTriviaSyntax _ when matchingNodes.Count >= 3:
                         // we are in a line that has a partial declaration keyword (for example "resour" or "modu")
@@ -304,25 +304,17 @@ namespace Bicep.LanguageServer.Completions
 
             switch (matchingNodes[^1])
             {
-                case ObjectSyntax _:
+                case ObjectSyntax objectSyntax:
                     // we are somewhere in the trivia portion of the object node (trivia span is not included in the token span)
                     // which is why the last node in the list of matching nodes is not a Token.
-                    return true;
+                    return CanInsertChildNodeAtOffset(objectSyntax, offset);
 
                 case Token token:
                     int nodeCount = matchingNodes.Count - objectInfo.index;
 
-                    switch (nodeCount)
+                    if (nodeCount == 2 && token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset((ObjectSyntax)matchingNodes[^2], offset))
                     {
-                        case 2 when token.Type == TokenType.NewLine:
-                            return true;
-
-                        case 4 when matchingNodes[^2] is IdentifierSyntax identifier && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, identifier):
-                            // we are in a partial or full property name
-                            return true;
-
-                        case 4 when matchingNodes[^2] is SkippedTriviaSyntax skipped && matchingNodes[^3] is ObjectPropertySyntax property && ReferenceEquals(property.Key, skipped):
-                            return true;
+                        return true;
                     }
 
                     break;
@@ -373,7 +365,7 @@ namespace Bicep.LanguageServer.Completions
                         (arrayAccess, @string, token) => token.Type == TokenType.StringComplete && ReferenceEquals(arrayAccess.IndexExpression, @string)));
         }
 
-        private static BicepCompletionContextKind GetObjectPropertyNameFlags(List<SyntaxBase> matchingNodes, (ObjectSyntax? node, int index) objectInfo)
+        private static BicepCompletionContextKind GetObjectPropertyNameFlags(List<SyntaxBase> matchingNodes, (ObjectSyntax? node, int index) objectInfo, int offset)
         {
             if (objectInfo.node == null)
             {
@@ -389,9 +381,11 @@ namespace Bicep.LanguageServer.Completions
             var isObjectProperty =
                 // we are somewhere in the trivia portion of the object node (trivia span is not included in the token span)
                 // which is why the last node in the list of matching nodes is not a Token.
-                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes, _ => true) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes, objectSyntax => CanInsertChildNodeAtOffset(objectSyntax, offset)) ||
 
-                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(matchingNodes, (_, token) => token.Type == TokenType.NewLine) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(
+                    matchingNodes,
+                    (objectSyntax, token) => token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset(objectSyntax, offset)) ||
 
                 // we are in a partial or full property name
                 SyntaxMatcher.IsTailMatch<ObjectSyntax, ObjectPropertySyntax, IdentifierSyntax, Token>(
@@ -446,7 +440,7 @@ namespace Bicep.LanguageServer.Completions
             return BicepCompletionContextKind.None;
         }
 
-        private static bool IsArrayItemContext(List<SyntaxBase> matchingNodes, (ArraySyntax? node, int index) arrayInfo)
+        private static bool IsArrayItemContext(List<SyntaxBase> matchingNodes, (ArraySyntax? node, int index) arrayInfo, int offset)
         {
             if (arrayInfo.node == null)
             {
@@ -457,8 +451,8 @@ namespace Bicep.LanguageServer.Completions
 
             switch (matchingNodes[^1])
             {
-                case ArraySyntax _:
-                    return true;
+                case ArraySyntax arraySyntax:
+                    return CanInsertChildNodeAtOffset(arraySyntax, offset);
 
                 case Token token:
                     int nodeCount = matchingNodes.Count - arrayInfo.index;
@@ -466,7 +460,7 @@ namespace Bicep.LanguageServer.Completions
                     switch (nodeCount)
                     {
                         case 2:
-                            return token.Type == TokenType.NewLine;
+                            return token.Type == TokenType.NewLine && CanInsertChildNodeAtOffset((ArraySyntax)matchingNodes[^2], offset);
 
                         case 5:
                             return token.Type == TokenType.Identifier;
@@ -607,6 +601,27 @@ namespace Bicep.LanguageServer.Completions
         /// <param name="matchingNodes">The matching nodes</param>
         private static bool IsInnerExpressionContext(List<SyntaxBase> matchingNodes, int offset)
         {
+            if (!matchingNodes.OfType<ExpressionSyntax>().Any())
+            {
+                // Fail fast.
+                return false;
+            }
+
+            var isBooleanOrNumberOrNull = SyntaxMatcher.IsTailMatch<Token>(matchingNodes, token => token.Type switch
+            {
+                TokenType.TrueKeyword => true,
+                TokenType.FalseKeyword => true,
+                TokenType.Integer => true,
+                TokenType.NullKeyword => true,
+                _ => false,
+            });
+
+            if (isBooleanOrNumberOrNull)
+            {
+                // Don't provide completions for a boolean, number, or null literal because it may be confusing.
+                return false;
+            }
+
             var isInStringSegment = SyntaxMatcher.IsTailMatch<StringSyntax, Token>(matchingNodes, (_, token) => token.Type switch
             {
                 // The cursor is immediately after the { character: '...${|...}...'.
@@ -626,20 +641,73 @@ namespace Bicep.LanguageServer.Completions
                 return false;
             }
 
-            // var foo = {|
-            // resource res '...' = {|
-            var isImmediatelyAfterOpenBrace = SyntaxMatcher.IsTailMatch<Token>(matchingNodes, token => token.Type switch
-            {
-                TokenType.LeftBrace when IsOffsetImmediatlyAfterNode(offset, token) => true,
-                _ => false,
-            });
+            // It does not make sense to insert expressions at the cursor positions shown in the comments below.
+            return  !(
+                //║{              ║{             ║|{|           ║{            ║{
+                //║  foo: true |  ║ | foo: true  ║  foo: true   ║  foo: true  ║  |
+                //║}              ║}             ║}             ║|}|          ║}
+                SyntaxMatcher.IsTailMatch<ObjectSyntax>(matchingNodes) ||
+                SyntaxMatcher.IsTailMatch<ObjectSyntax, Token>(matchingNodes) ||
 
-            if (isImmediatelyAfterOpenBrace)
-            {
-                return false;
-            }
+                //║[         ║[        ║|[|      ║[
+                //║  true |  ║ | true  ║  true   ║  true
+                //║]         ║]        ║]        ║|]|
+                SyntaxMatcher.IsTailMatch<ArraySyntax>(matchingNodes) ||
+                SyntaxMatcher.IsTailMatch<ArraySyntax, Token>(
+                    matchingNodes,
+                    (arraySyntax, token) => token.Type != TokenType.NewLine || !CanInsertChildNodeAtOffset(arraySyntax, offset)) ||
 
-            return matchingNodes.OfType<ExpressionSyntax>().Any();
+                // var foo = ! | bar
+                SyntaxMatcher.IsTailMatch<UnaryOperationSyntax>(
+                    matchingNodes,
+                    unaryOperation => !unaryOperation.Expression.IsOverlapping(offset)) ||
+
+                // var foo = |!bar
+                // var foo = !| bar
+                SyntaxMatcher.IsTailMatch<UnaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (unaryOperation, operatorToken) =>
+                        operatorToken.GetPosition() == offset ||
+                        (operatorToken.GetEndPosition() == offset && unaryOperation.Expression is not SkippedTriviaSyntax)) ||
+
+                // var foo = 1 | + ...
+                // var foo = 1 + | 2
+                SyntaxMatcher.IsTailMatch<BinaryOperationSyntax>(
+                    matchingNodes,
+                    binaryOperation =>
+                        !binaryOperation.LeftExpression.IsOverlapping(offset) &&
+                        !binaryOperation.RightExpression.IsOverlapping(offset)) ||
+
+                // var foo = 1 |+ ...
+                // var foo = 1 +| 2
+                SyntaxMatcher.IsTailMatch<BinaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (binaryOperation, operatorToken) =>
+                        (operatorToken.GetPosition() == offset && binaryOperation.LeftExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.GetEndPosition() == offset && binaryOperation.RightExpression is not SkippedTriviaSyntax)) ||
+
+                // var foo = true | ? ...
+                // var foo = true ? | 'yes'
+                // var foo = true ? 'yes' | : ...
+                // var foo = true ? 'yes' : | 'no'
+                SyntaxMatcher.IsTailMatch<TernaryOperationSyntax>(
+                    matchingNodes,
+                    ternaryOperation =>
+                        !ternaryOperation.ConditionExpression.IsOverlapping(offset) &&
+                        !ternaryOperation.TrueExpression.IsOverlapping(offset) &&
+                        !ternaryOperation.FalseExpression.IsOverlapping(offset)) ||
+
+                // var foo = true |? ...
+                // var foo = true ?| 'yes'
+                // var foo = true ? 'yes' |: ...
+                // var foo = true ? 'yes' :| 'no'
+                SyntaxMatcher.IsTailMatch<TernaryOperationSyntax, Token>(
+                    matchingNodes,
+                    (ternaryOperation, operatorToken) =>
+                        (operatorToken.Type == TokenType.Question && operatorToken.GetPosition() == offset && ternaryOperation.ConditionExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Question && operatorToken.GetEndPosition() == offset && ternaryOperation.TrueExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Colon && operatorToken.GetPosition() == offset && ternaryOperation.TrueExpression is not SkippedTriviaSyntax) ||
+                        (operatorToken.Type == TokenType.Colon && operatorToken.GetEndPosition() == offset && ternaryOperation.FalseExpression is not SkippedTriviaSyntax)));
         }
         
         static bool IsOffsetImmediatlyAfterNode(int offset, SyntaxBase node) => node.Span.Position + node.Span.Length == offset;
@@ -656,6 +724,64 @@ namespace Bicep.LanguageServer.Completions
             // (non-replaceable tokens include colons, newlines, parens, etc.)
             // produce an insertion edit
             return new TextSpan(offset, 0).ToRange(syntaxTree.LineStarts);
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ProgramSyntax programSyntax, int offset)
+        {
+            var enclosingNode = programSyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var lastNodeBeforeOffset = programSyntax.Children.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = programSyntax.Children.FirstOrDefault(node => node.GetPosition() >= offset);
+
+            // Ensure we are in between newlines.
+            return lastNodeBeforeOffset is null or Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is null or Token { Type: TokenType.NewLine };
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ObjectSyntax objectSyntax, int offset)
+        {
+            var enclosingNode = objectSyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var nodes = objectSyntax.OpenBrace.AsEnumerable().Concat(objectSyntax.Children).Concat(objectSyntax.CloseBrace);
+            var lastNodeBeforeOffset = nodes.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = nodes.FirstOrDefault(node => node.GetPosition() >= offset);
+
+            // To insert a new child in an object, we must be in between newlines.
+            // This will not be the case once https://github.com/Azure/bicep/issues/146 is implemented.
+            return lastNodeBeforeOffset is Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is Token { Type: TokenType.NewLine };
+        }
+
+        private static bool CanInsertChildNodeAtOffset(ArraySyntax arraySyntax, int offset)
+        {
+            var enclosingNode = arraySyntax.Children.FirstOrDefault(child => child.IsEnclosing(offset));
+
+            if (enclosingNode is Token { Type: TokenType.NewLine })
+            {
+                // /r/n|/r/n
+                return true;
+            }
+
+            var nodes = arraySyntax.OpenBracket.AsEnumerable().Concat(arraySyntax.Children).Concat(arraySyntax.CloseBracket);
+            var lastNodeBeforeOffset = nodes.LastOrDefault(node => node.GetEndPosition() <= offset);
+            var firstNodeAfterOffset = nodes.FirstOrDefault(node => node.GetPosition() >= offset);
+
+            // To insert a new child in an array, we must be in between newlines.
+            // This will not be the case once https://github.com/Azure/bicep/issues/146 is implemented.
+            return lastNodeBeforeOffset is Token { Type: TokenType.NewLine } &&
+                firstNodeAfterOffset is Token { Type: TokenType.NewLine };
         }
 
         private class ActiveScopesVisitor : SymbolVisitor

--- a/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
+++ b/src/Bicep.LangServer/Completions/BicepCompletionProvider.cs
@@ -28,8 +28,6 @@ namespace Bicep.LanguageServer.Completions
     {
         private const string MarkdownNewLine = "  \n";
 
-        private static readonly Container<string> PropertyCommitChars = new(":");
-
         private static readonly Container<string> ResourceSymbolCommitChars = new(":");
 
         private static readonly Container<string> PropertyAccessCommitChars = new(".");
@@ -818,7 +816,6 @@ namespace Bicep.LanguageServer.Completions
                 .WithLabel(property.Name)
                 // property names that much Bicep keywords or containing non-identifier chars need to be escaped
                 .WithPlainTextEdit(replacementRange, $"{escapedPropertyName}{suffix}")
-                .WithCommitCharacters(PropertyCommitChars)
                 .WithDetail(FormatPropertyDetail(property))
                 .WithDocumentation(FormatPropertyDocumentation(property))
                 .WithSortText(GetSortText(property.Name, priority));

--- a/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/ISnippetsProvider.cs
@@ -10,6 +10,8 @@ namespace Bicep.LanguageServer.Snippets
     {
         IEnumerable<Snippet> GetTopLevelNamedDeclarationSnippets();
 
+        IEnumerable<Snippet> GetModuleBodyCompletionSnippets(TypeSymbol typeSymbol);
+
         IEnumerable<Snippet> GetResourceBodyCompletionSnippets(TypeSymbol typeSymbol, bool isExistingResource);
     }
 }

--- a/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
+++ b/src/Bicep.LangServer/Snippets/SnippetsProvider.cs
@@ -248,18 +248,17 @@ namespace Bicep.LanguageServer.Snippets
         private IEnumerable<Snippet> GetResourceBodyCompletionSnippetFromAzTypes(TypeSymbol typeSymbol)
         {
             string description = "Required properties";
-            List<Snippet> snippets = new List<Snippet>();
 
             if (typeSymbol is ResourceType resourceType)
             {
                 if (resourceType.Body is ObjectType objectType)
                 {
                     string label = "required-properties";
-                    Snippet? snippet = GetResourceBodySnippet(objectType, label, description);
+                    Snippet? snippet = GetRequiredPropertiesSnippet(objectType, label, description);
 
                     if (snippet is not null)
                     {
-                        snippets.Add(snippet);
+                        yield return snippet;
                     }
                 }
                 else if (resourceType.Body is DiscriminatedObjectType discriminatedObjectType)
@@ -267,20 +266,18 @@ namespace Bicep.LanguageServer.Snippets
                     foreach (KeyValuePair<string, ObjectType> kvp in discriminatedObjectType.UnionMembersByKey.OrderBy(x => x.Key))
                     {
                         string label = "required-properties-" + kvp.Key.Trim(new char[] { '\'' });
-                        Snippet? snippet = GetResourceBodySnippet(kvp.Value, label, description);
+                        Snippet? snippet = GetRequiredPropertiesSnippet(kvp.Value, label, description);
 
                         if (snippet is not null)
                         {
-                            snippets.Add(snippet);
+                            yield return snippet;
                         }
                     }
                 }
             }
-
-            return snippets;
         }
 
-        private Snippet? GetResourceBodySnippet(ObjectType objectType, string label, string description)
+        private Snippet? GetRequiredPropertiesSnippet(ObjectType objectType, string label, string description)
         {
             int index = 1;
             StringBuilder sb = new StringBuilder();
@@ -359,6 +356,23 @@ namespace Bicep.LanguageServer.Snippets
             string label = "{}";
 
             return new Snippet("{\n\t$0\n}", CompletionPriority.Medium, label, label);
+        }
+
+        public IEnumerable<Snippet> GetModuleBodyCompletionSnippets(TypeSymbol typeSymbol)
+        {
+            yield return GetEmptySnippet();
+
+            if (typeSymbol is ModuleType moduleType && moduleType.Body is ObjectType objectType)
+            {
+                string label = "required-properties";
+                string description = "Required properties";
+                Snippet? snippet = GetRequiredPropertiesSnippet(objectType, label, description);
+
+                if (snippet is not null)
+                {
+                    yield return snippet;
+                }
+            }
         }
     }
 }

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-cassandra-keyspace.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-cassandra-keyspace.bicep
@@ -1,5 +1,5 @@
-﻿// Cosmos DB Gremlin Database
-resource ${1:gremlinDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+﻿// Cosmos DB Cassandra Namespace
+resource ${1:cassandraKeyspace} 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
   name: ${2:'name'}
   properties: {
     resource: {

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-cassandra-table.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-cassandra-table.bicep
@@ -1,0 +1,21 @@
+﻿// Cosmos DB Cassandra Table
+resource cassandraKeyspace 'Microsoft.DocumentDB/databaseAccounts/apis/keyspaces@2016-03-31' = {
+  name: ${1:'name'}
+  properties: {
+    resource: {
+      id: ${2:'id'}
+    }
+    options: {}
+  }
+}
+
+resource ${3:cassandraKeyspaceTable} 'Microsoft.DocumentDb/databaseAccounts/apis/keyspaces/tables@2016-03-31' = {
+  parent: cassandraKeyspace
+  name: ${4:'name'}
+  properties: {
+    resource: {
+      id: ${5:'id'}
+    }
+    options: {}
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-gremlin-graph.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-gremlin-graph.bicep
@@ -1,5 +1,5 @@
 ﻿// Cosmos DB Gremlin Graph
-resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+resource gremlinDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: ${1:'name'}
   properties: {
     resource: {
@@ -11,8 +11,8 @@ resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2
   }
 }
 
-resource ${4:cosmosDBGremlinGraph} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {
-  parent: databaseAccount
+resource ${4:cosmosDbGremlinGraph} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/graphs@2016-03-31' = {
+  parent: gremlinDb
   name: ${5:'name'}
   properties: {
     resource: {

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-mongo-database.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-mongo-database.bicep
@@ -1,0 +1,10 @@
+﻿// Cosmos DB Mongo Database
+resource ${1:mongoDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+  name: ${2:'name'}
+  properties: {
+    resource: {
+      id: ${3:'id'}
+    }
+    options: {}
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-sql-container.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-sql-container.bicep
@@ -1,0 +1,47 @@
+﻿// Cosmos DB SQL Container
+resource sqlDb 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+  name: ${1:'name'}
+  properties: {
+    resource: {
+      id: ${2:'id'}
+    }
+    options: {}
+  }
+}
+
+resource ${3:sqlContainerName} 'Microsoft.DocumentDb/databaseAccounts/apis/databases/containers@2016-03-31' = {
+  parent: sqlDb 
+  name: ${4:'name'}
+  properties: {
+    resource: {
+      id: ${5:'id'}
+      partitionKey: {
+        paths: [
+          ${6:'paths'}
+        ]
+        kind: '${7|Hash,Range|}'
+      }
+      indexingPolicy: {
+        indexingMode: '${8|Consistent,Lazy,None|}'
+        includedPaths: [
+          {
+            path: ${9:'path'}
+            indexes: [
+              {
+                kind: '${10|Hash,Range,Spatial|}'
+                dataType: '${11|String,Number,Point,Polygon,LineString,MultiPolygon|}'
+                precision: ${12:'precision'}
+              }
+            ]
+          }
+        ]
+        excludedPaths: [
+          {
+            path: ${13:'path'}
+          }
+        ]
+      }
+    }
+    options: {}
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-sql-database.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-sql-database.bicep
@@ -1,5 +1,5 @@
-﻿// Cosmos DB Gremlin Database
-resource ${1:gremlinDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+﻿// Cosmos DB SQL Database
+resource ${1:sqlDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
   name: ${2:'name'}
   properties: {
     resource: {

--- a/src/Bicep.LangServer/Snippets/Templates/res-cosmos-tablestorage-table.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-cosmos-tablestorage-table.bicep
@@ -1,5 +1,5 @@
-﻿// Cosmos DB Gremlin Database
-resource ${1:gremlinDb} 'Microsoft.DocumentDB/databaseAccounts/apis/databases@2016-03-31' = {
+﻿// Cosmos Table Storage
+resource ${1:cosmosTable} 'Microsoft.DocumentDB/databaseAccounts/apis/tables@2016-03-31' = {
   name: ${2:'name'}
   properties: {
     resource: {

--- a/src/Bicep.LangServer/Snippets/Templates/res-log-analytics-solution.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-log-analytics-solution.bicep
@@ -1,0 +1,17 @@
+﻿// Log Analytics Solution
+resource ${1:logAnalyticsSolution} 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = {
+  name: ${2:'name'}
+  location: resourceGroup().location
+  properties: {
+    workspaceResourceId: resourceId('Microsoft.OperationalInsights/workspaces', ${3:'logAnalyticsWorkspace'})
+    containedResources: [
+      resourceId('Microsoft.OperationalInsights/workspaces/views', ${3:'logAnalyticsWorkspace'}, ${4:'logAnalyticsSolution'})
+    ]
+  }
+  plan: {
+    name: ${5:'name'}
+    product: ${6:'product'}
+    publisher: ${7:'publisher'}
+    promotionCode: ${8:'promotionCode'}
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-media.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-media.bicep
@@ -1,0 +1,13 @@
+﻿// Media Services account
+resource ${1:mediaServices} 'Microsoft.Media/mediaServices@2020-05-01' = {
+  name: ${2:'name'}
+  location: resourceGroup().location
+  properties: {
+    storageAccounts: [
+      {
+        id: resourceId('Microsoft.Storage/storageAccounts', ${3:'mediaServiceStorageAccount'})
+        type: '${4|Primary,Secondary|}'
+      }
+    ]
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-nic.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-nic.bicep
@@ -1,0 +1,18 @@
+﻿// Network Interface
+resource ${1:networkInterface} 'Microsoft.Network/networkInterfaces@2020-11-01' = {
+  name: ${2:'name'}
+  location: resourceGroup().location
+  properties: {
+    ipConfigurations: [
+      {
+        name: ${3:'name'}
+        properties: {
+          privateIPAllocationMethod: '${4|Dynamic,Static|}'
+          subnet: {
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', ${5:'virtualNetwork'}, ${6:'subnet'})
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/Bicep.LangServer/Snippets/Templates/res-sql.bicep
+++ b/src/Bicep.LangServer/Snippets/Templates/res-sql.bicep
@@ -1,0 +1,17 @@
+﻿// SQL Database
+resource sqlServer 'Microsoft.Sql/servers@2014-04-01' ={
+  name: ${1:'name'}
+  location: resourceGroup().location
+}
+
+resource ${2:sqlServerDatabase} 'Microsoft.Sql/servers/databases@2014-04-01' = {
+  parent: sqlServer
+  name: ${3:'name'}
+  location: resourceGroup().location
+  properties: {
+    collation: ${4:'collation'}
+    edition: '${5|Basic,Business,BusinessCritical,DataWarehouse,Free,GeneralPurpose,Hyperscale,Premium,PremiumRS,Standard,Stretch,System,System2,Web|}'
+    maxSizeBytes: ${6:'maxSizeBytes'}
+    requestedServiceObjectiveName: '${7|Basic,DS100,DS1000,DS1200,DS1500,DS200,DS2000,DS300,DS400,DS500,DS600,DW100,DW1000,DW10000c,DW1000c,DW1200,DW1500,DW15000c,DW1500c,DW200,DW2000,DW2000c,DW2500c,DW300,DW3000,DW30000c,DW3000c,DW400,DW500,DW5000c,DW600,DW6000,DW6000c,DW7500c,ElasticPool,Free,P1,P11,P15,P2,P3,P4,P6,PRS1,PRS2,PRS4,PRS6,S0,S1,S12,S2,S3,S4,S6,S7,S9,System,System0,System1,System2,System2L,System3,System3L,System4,System4L|}'
+  }
+}

--- a/src/highlightjs/package-lock.json
+++ b/src/highlightjs/package-lock.json
@@ -9,7 +9,7 @@
       "devDependencies": {
         "@types/highlight.js": "^10.1.0",
         "@types/jest": "^26.0.23",
-        "@types/node": "^15.0.2",
+        "@types/node": "^15.0.3",
         "@types/plist": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
@@ -1048,9 +1048,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -8364,9 +8364,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/highlightjs/package.json
+++ b/src/highlightjs/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@types/highlight.js": "^10.1.0",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.0.3",
     "@types/plist": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",

--- a/src/monarch/package-lock.json
+++ b/src/monarch/package-lock.json
@@ -9,7 +9,7 @@
       "devDependencies": {
         "@types/html-escaper": "^3.0.0",
         "@types/jest": "^26.0.23",
-        "@types/node": "^15.0.2",
+        "@types/node": "^15.0.3",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
         "eslint": "^7.26.0",
@@ -1014,9 +1014,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -8161,9 +8161,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/monarch/package-lock.json
+++ b/src/monarch/package-lock.json
@@ -18,7 +18,7 @@
         "html-escaper": "^3.0.3",
         "jest": "^26.6.3",
         "jest-esm-transformer": "^1.0.0",
-        "monaco-editor-core": "^0.23.0",
+        "monaco-editor-core": "^0.24.0",
         "ts-jest": "^26.5.6",
         "ts-node": "^9.1.1",
         "typescript": "^4.2.4"
@@ -4709,9 +4709,9 @@
       }
     },
     "node_modules/monaco-editor-core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.23.0.tgz",
-      "integrity": "sha512-1LHVpCHp+FErFdUjwzal1muTe+hUkR5CfXAxzua//eHB31bHdWVe15OJPEPS3/rxmfQtl9wZqJdHi4FcGz2zog==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.24.0.tgz",
+      "integrity": "sha512-WJAzpNYEaJp8Z7crIAiLCVln1zZdo4cFXCRuhTDN4A3tz6IK2NOXAtTOZ9iLKBTtd6eitZJ2Q1Fx8JN8rN3fWw==",
       "dev": true
     },
     "node_modules/ms": {
@@ -11087,9 +11087,9 @@
       "dev": true
     },
     "monaco-editor-core": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.23.0.tgz",
-      "integrity": "sha512-1LHVpCHp+FErFdUjwzal1muTe+hUkR5CfXAxzua//eHB31bHdWVe15OJPEPS3/rxmfQtl9wZqJdHi4FcGz2zog==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.24.0.tgz",
+      "integrity": "sha512-WJAzpNYEaJp8Z7crIAiLCVln1zZdo4cFXCRuhTDN4A3tz6IK2NOXAtTOZ9iLKBTtd6eitZJ2Q1Fx8JN8rN3fWw==",
       "dev": true
     },
     "ms": {

--- a/src/monarch/package.json
+++ b/src/monarch/package.json
@@ -13,7 +13,7 @@
     "html-escaper": "^3.0.3",
     "jest": "^26.6.3",
     "jest-esm-transformer": "^1.0.0",
-    "monaco-editor-core": "^0.23.0",
+    "monaco-editor-core": "^0.24.0",
     "ts-jest": "^26.5.6",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"

--- a/src/monarch/package.json
+++ b/src/monarch/package.json
@@ -4,7 +4,7 @@
   "devDependencies": {
     "@types/html-escaper": "^3.0.0",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.0.3",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "eslint": "^7.26.0",

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/copy-webpack-plugin": "^8.0.0",
-        "@types/node": "^15.0.2",
+        "@types/node": "^15.0.3",
         "@types/pako": "^1.0.1",
         "@types/react": "^17.0.5",
         "@types/react-dom": "^17.0.4",
@@ -375,9 +375,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "node_modules/@types/pako": {
@@ -8711,9 +8711,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "@types/pako": {

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.0.0-placeholder",
       "dependencies": {
         "bootstrap": "^5.0.0",
-        "monaco-editor": "^0.23.0",
+        "monaco-editor": "^0.24.0",
         "pako": "^2.0.3",
         "react": "^17.0.2",
         "react-bootstrap": "^1.6.0",
@@ -4977,9 +4977,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.23.0.tgz",
-      "integrity": "sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.24.0.tgz",
+      "integrity": "sha512-o1f0Lz6ABFNTtnEqqqvlY9qzNx24rQZx1RgYNQ8SkWkE+Ka63keHH/RqxQ4QhN4fs/UYOnvAtEUZsPrzccH++A=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "3.1.0",
@@ -12430,9 +12430,9 @@
       }
     },
     "monaco-editor": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.23.0.tgz",
-      "integrity": "sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.24.0.tgz",
+      "integrity": "sha512-o1f0Lz6ABFNTtnEqqqvlY9qzNx24rQZx1RgYNQ8SkWkE+Ka63keHH/RqxQ4QhN4fs/UYOnvAtEUZsPrzccH++A=="
     },
     "monaco-editor-webpack-plugin": {
       "version": "3.1.0",

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-jest": "^24.3.6",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.3.1",
-        "monaco-editor-webpack-plugin": "^3.0.1",
+        "monaco-editor-webpack-plugin": "^3.1.0",
         "nerdbank-gitversioning": "^3.4.194",
         "style-loader": "^2.0.0",
         "ts-loader": "^9.1.2",
@@ -4982,15 +4982,15 @@
       "integrity": "sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg=="
     },
     "node_modules/monaco-editor-webpack-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-3.0.1.tgz",
-      "integrity": "sha512-Hym4HqWgIpyoi9G0spln/b/7rkDKfYwIOrNzo1fHHMc+MLYSwD1JXHwKSDS77X27ZHfVJsEXbMZYdGhSYuVF0w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha512-TP5NkCAV0OeFTry5k/d60KR7CkhTXL4kgJKtE3BzjgbDb5TGEPEhoKmHBrSa6r7Oc0sNbPLZhKD/TP2ig7A+/A==",
       "dev": true,
       "dependencies": {
         "loader-utils": "^2.0.0"
       },
       "peerDependencies": {
-        "monaco-editor": "0.22.x || 0.23.x",
+        "monaco-editor": "0.22.x || 0.23.x || 0.24.x",
         "webpack": "^4.5.0 || 5.x"
       }
     },
@@ -12435,9 +12435,9 @@
       "integrity": "sha512-q+CP5zMR/aFiMTE9QlIavGyGicKnG2v/H8qVvybLzeFsARM8f6G9fL0sMST2tyVYCwDKkGamZUI6647A0jR/Lg=="
     },
     "monaco-editor-webpack-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-3.0.1.tgz",
-      "integrity": "sha512-Hym4HqWgIpyoi9G0spln/b/7rkDKfYwIOrNzo1fHHMc+MLYSwD1JXHwKSDS77X27ZHfVJsEXbMZYdGhSYuVF0w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha512-TP5NkCAV0OeFTry5k/d60KR7CkhTXL4kgJKtE3BzjgbDb5TGEPEhoKmHBrSa6r7Oc0sNbPLZhKD/TP2ig7A+/A==",
       "dev": true,
       "requires": {
         "loader-utils": "^2.0.0"

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^15.0.3",
         "@types/pako": "^1.0.1",
         "@types/react": "^17.0.5",
-        "@types/react-dom": "^17.0.4",
+        "@types/react-dom": "^17.0.5",
         "@types/webpack": "^5.28.0",
         "@types/webpack-dev-server": "^3.11.4",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.4.tgz",
-      "integrity": "sha512-Wb6rlnPJfqbhpkvYN39y1NM/pOGGPzzIRquu0RdUMvTwgXNvASFO7pdtrtvyxGTQNb9wzBaQxXAWDdEqegZw2A==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
+      "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -8750,9 +8750,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.4.tgz",
-      "integrity": "sha512-Wb6rlnPJfqbhpkvYN39y1NM/pOGGPzzIRquu0RdUMvTwgXNvASFO7pdtrtvyxGTQNb9wzBaQxXAWDdEqegZw2A==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
+      "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/src/playground/package-lock.json
+++ b/src/playground/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "version": "0.0.0-placeholder",
       "dependencies": {
-        "bootstrap": "^5.0.0",
+        "bootstrap": "^5.0.1",
         "monaco-editor": "^0.24.0",
         "pako": "^2.0.3",
         "react": "^17.0.2",
@@ -1418,9 +1418,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0.tgz",
-      "integrity": "sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
+      "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/bootstrap"
@@ -9558,9 +9558,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.0.tgz",
-      "integrity": "sha512-tmhPET9B9qCl8dCofvHeiIhi49iBt0EehmIsziZib65k1erBW1rHhj2s/2JsuQh5Pq+xz2E9bEbzp9B7xHG+VA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.0.1.tgz",
+      "integrity": "sha512-Fl79+wsLOZKoiU345KeEaWD0ik8WKRI5zm0YSPj2oF1Qr+BO7z0fco6GbUtqjoG1h4VI89PeKJnMsMMVQdKKTw==",
       "requires": {}
     },
     "brace-expansion": {

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-jest": "^24.3.6",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",
-    "monaco-editor-webpack-plugin": "^3.0.1",
+    "monaco-editor-webpack-plugin": "^3.1.0",
     "nerdbank-gitversioning": "^3.4.194",
     "style-loader": "^2.0.0",
     "ts-loader": "^9.1.2",

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -14,7 +14,7 @@
   "private": true,
   "devDependencies": {
     "@types/copy-webpack-plugin": "^8.0.0",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.0.3",
     "@types/pako": "^1.0.1",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.4",

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.0.0",
-    "monaco-editor": "^0.23.0",
+    "monaco-editor": "^0.24.0",
     "pako": "^2.0.3",
     "react": "^17.0.2",
     "react-bootstrap": "^1.6.0",

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -40,7 +40,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
-    "bootstrap": "^5.0.0",
+    "bootstrap": "^5.0.1",
     "monaco-editor": "^0.24.0",
     "pako": "^2.0.3",
     "react": "^17.0.2",

--- a/src/playground/package.json
+++ b/src/playground/package.json
@@ -17,7 +17,7 @@
     "@types/node": "^15.0.3",
     "@types/pako": "^1.0.1",
     "@types/react": "^17.0.5",
-    "@types/react-dom": "^17.0.4",
+    "@types/react-dom": "^17.0.5",
     "@types/webpack": "^5.28.0",
     "@types/webpack-dev-server": "^3.11.4",
     "@typescript-eslint/eslint-plugin": "^4.23.0",

--- a/src/textmate/package-lock.json
+++ b/src/textmate/package-lock.json
@@ -10,7 +10,7 @@
         "@azure-tools/tmlanguage-generator": "^0.1.4",
         "@types/html-escaper": "^3.0.0",
         "@types/jest": "^26.0.23",
-        "@types/node": "^15.0.2",
+        "@types/node": "^15.0.3",
         "@types/plist": "^3.0.2",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
@@ -999,9 +999,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -8519,9 +8519,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/textmate/package.json
+++ b/src/textmate/package.json
@@ -5,7 +5,7 @@
     "@azure-tools/tmlanguage-generator": "^0.1.4",
     "@types/html-escaper": "^3.0.0",
     "@types/jest": "^26.0.23",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.0.3",
     "@types/plist": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-prettier": "^3.4.0",
         "eslint-plugin-react": "^7.23.2",
-        "fork-ts-checker-webpack-plugin": "^6.2.7",
+        "fork-ts-checker-webpack-plugin": "^6.2.8",
         "jest": "^26.6.2",
         "jest-styled-components": "^7.0.4",
         "ncp": "^2.0.0",
@@ -4986,9 +4986,9 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.7.tgz",
-      "integrity": "sha512-uGl/x5aiWbBtKT3QtXYuuK/gY1BfN0/RNM/BZvu2o2QdPE7FemyNIxVAgUUbPTm4l90MwWStfVVb7Bu5nyHglg==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.8.tgz",
+      "integrity": "sha512-KduEntkrnDejqZ6zw8+pRpsENPtBNP9J92bJIFXBi96tySa3csyZiVIyqKwdN3KqpVWwtQIcu3j91DDbvuWB4A==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.8.3",
@@ -15357,9 +15357,9 @@
       "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.7.tgz",
-      "integrity": "sha512-uGl/x5aiWbBtKT3QtXYuuK/gY1BfN0/RNM/BZvu2o2QdPE7FemyNIxVAgUUbPTm4l90MwWStfVVb7Bu5nyHglg==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.8.tgz",
+      "integrity": "sha512-KduEntkrnDejqZ6zw8+pRpsENPtBNP9J92bJIFXBi96tySa3csyZiVIyqKwdN3KqpVWwtQIcu3j91DDbvuWB4A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -14,7 +14,7 @@
         "react-dom": "^17.0.2",
         "styled-components": "^5.3.0",
         "triple-beam": "^1.3.0",
-        "vscode-azureextensionui": "^0.43.3",
+        "vscode-azureextensionui": "^0.43.4",
         "vscode-languageclient": "^7.0.0",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0"
@@ -10457,9 +10457,9 @@
       }
     },
     "node_modules/vscode-azureextensionui": {
-      "version": "0.43.3",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
-      "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
+      "version": "0.43.4",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.4.tgz",
+      "integrity": "sha512-4NI0GSIRY/mVfy2Uut0o7xFnA7ZtpZE1t7h4t51xqnDIwH1/K33zEGTeMJy9MHlSiDYVC3urM2nLpKdAiLiS9w==",
       "dependencies": {
         "@azure/arm-resources": "^3.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",
@@ -19844,9 +19844,9 @@
       }
     },
     "vscode-azureextensionui": {
-      "version": "0.43.3",
-      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.3.tgz",
-      "integrity": "sha512-a2I7Se3rURoqfLXxFMwJ3R0wn5Kvsp3jdC1hfP7k0RNg2QD9twyCDTl4R/6DqQE+WhFD5ZD2FVsRzzcfnlTgQw==",
+      "version": "0.43.4",
+      "resolved": "https://registry.npmjs.org/vscode-azureextensionui/-/vscode-azureextensionui-0.43.4.tgz",
+      "integrity": "sha512-4NI0GSIRY/mVfy2Uut0o7xFnA7ZtpZE1t7h4t51xqnDIwH1/K33zEGTeMJy9MHlSiDYVC3urM2nLpKdAiLiS9w==",
       "requires": {
         "@azure/arm-resources": "^3.0.0",
         "@azure/arm-resources-profile-2020-09-01-hybrid": "^1.0.0",

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -24,7 +24,7 @@
         "@types/cytoscape": "^3.14.15",
         "@types/jest": "^26.0.23",
         "@types/mocha": "^8.2.2",
-        "@types/node": "^15.0.2",
+        "@types/node": "^15.0.3",
         "@types/react": "^17.0.5",
         "@types/react-dom": "^17.0.4",
         "@types/react-test-renderer": "^17.0.1",
@@ -1287,9 +1287,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -12278,9 +12278,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
+      "version": "15.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.3.tgz",
+      "integrity": "sha512-/WbxFeBU+0F79z9RdEOXH4CsDga+ibi5M8uEYr91u3CkT/pdWcV8MCook+4wDPnZBexRdwWS+PiVZ2xJviAzcQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -28,7 +28,7 @@
         "@types/react": "^17.0.5",
         "@types/react-dom": "^17.0.5",
         "@types/react-test-renderer": "^17.0.1",
-        "@types/semver": "^7.3.5",
+        "@types/semver": "^7.3.6",
         "@types/styled-components": "^5.1.9",
         "@types/triple-beam": "^1.3.2",
         "@types/vscode": "^1.52.0",
@@ -1352,9 +1352,9 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-iotVxtCCsPLRAvxMFFgxL8HD2l4mAZ2Oin7/VJ2ooWO0VOK4EGOGmZWZn1uCq7RofR3I/1IOSjCHlFT71eVK0Q==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -12343,9 +12343,9 @@
       "dev": true
     },
     "@types/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-iotVxtCCsPLRAvxMFFgxL8HD2l4mAZ2Oin7/VJ2ooWO0VOK4EGOGmZWZn1uCq7RofR3I/1IOSjCHlFT71eVK0Q==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.6.tgz",
+      "integrity": "sha512-0caWDWmpCp0uifxFh+FaqK3CuZ2SkRR/ZRxAV5+zNdC3QVUi6wyOJnefhPvtNt8NQWXB5OA93BUvZsXpWat2Xw==",
       "dev": true
     },
     "@types/stack-utils": {

--- a/src/vscode-bicep/package-lock.json
+++ b/src/vscode-bicep/package-lock.json
@@ -26,7 +26,7 @@
         "@types/mocha": "^8.2.2",
         "@types/node": "^15.0.3",
         "@types/react": "^17.0.5",
-        "@types/react-dom": "^17.0.4",
+        "@types/react-dom": "^17.0.5",
         "@types/react-test-renderer": "^17.0.1",
         "@types/semver": "^7.3.5",
         "@types/styled-components": "^5.1.9",
@@ -1328,9 +1328,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.4.tgz",
-      "integrity": "sha512-Wb6rlnPJfqbhpkvYN39y1NM/pOGGPzzIRquu0RdUMvTwgXNvASFO7pdtrtvyxGTQNb9wzBaQxXAWDdEqegZw2A==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
+      "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -12319,9 +12319,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.4.tgz",
-      "integrity": "sha512-Wb6rlnPJfqbhpkvYN39y1NM/pOGGPzzIRquu0RdUMvTwgXNvASFO7pdtrtvyxGTQNb9wzBaQxXAWDdEqegZw2A==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.5.tgz",
+      "integrity": "sha512-ikqukEhH4H9gr4iJCmQVNzTB307kROe3XFfHAOTxOXPOw7lAoEXnM5KWTkzeANGL5Ce6ABfiMl/zJBYNi7ObmQ==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -231,7 +231,7 @@
     "react-dom": "^17.0.2",
     "styled-components": "^5.3.0",
     "triple-beam": "^1.3.0",
-    "vscode-azureextensionui": "^0.43.3",
+    "vscode-azureextensionui": "^0.43.4",
     "vscode-languageclient": "^7.0.0",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0"

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -206,7 +206,7 @@
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.23.2",
-    "fork-ts-checker-webpack-plugin": "^6.2.7",
+    "fork-ts-checker-webpack-plugin": "^6.2.8",
     "jest": "^26.6.2",
     "jest-styled-components": "^7.0.4",
     "ncp": "^2.0.0",

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -187,7 +187,7 @@
     "@types/cytoscape": "^3.14.15",
     "@types/jest": "^26.0.23",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^15.0.2",
+    "@types/node": "^15.0.3",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.4",
     "@types/react-test-renderer": "^17.0.1",

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -191,7 +191,7 @@
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.5",
     "@types/react-test-renderer": "^17.0.1",
-    "@types/semver": "^7.3.5",
+    "@types/semver": "^7.3.6",
     "@types/styled-components": "^5.1.9",
     "@types/triple-beam": "^1.3.2",
     "@types/vscode": "^1.52.0",

--- a/src/vscode-bicep/package.json
+++ b/src/vscode-bicep/package.json
@@ -189,7 +189,7 @@
     "@types/mocha": "^8.2.2",
     "@types/node": "^15.0.3",
     "@types/react": "^17.0.5",
-    "@types/react-dom": "^17.0.4",
+    "@types/react-dom": "^17.0.5",
     "@types/react-test-renderer": "^17.0.1",
     "@types/semver": "^7.3.5",
     "@types/styled-components": "^5.1.9",


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

* [ ] I have checked that there is not an equivalent example already submitted
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
