### PR TITLE
Sync with source

### DIFF
--- a/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
+++ b/src/Bicep.Core/Workspaces/SourceFileGrouping.cs
@@ -48,6 +48,9 @@ namespace Bicep.Core.Workspaces
         public ISourceFile LookUpModuleSourceFile(ModuleDeclarationSyntax moduleDeclaration) =>
             this.SourceFilesByModuleDeclaration[moduleDeclaration];
 
+        public ISourceFile? TryLookupModuleSourceFile(ModuleDeclarationSyntax moduleDeclaration) =>
+            this.SourceFilesByModuleDeclaration.TryGetValue(moduleDeclaration, out var sourceFile) ? sourceFile : null;
+
         public ImmutableHashSet<ISourceFile> GetFilesDependingOn(ISourceFile sourceFile)
         {
             var filesToCheck = new Queue<ISourceFile>(new [] { sourceFile });

--- a/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
+++ b/src/Bicep.Decompiler.IntegrationTests/DecompilationTests.cs
@@ -144,6 +144,8 @@ namespace Bicep.Core.IntegrationTests
         [DataTestMethod]
         [DataRow("NonWorking/unknownprops.json", "[15:29]: Unrecognized top-level resource property 'madeUpProperty'")]
         [DataRow("NonWorking/invalid-schema.json", "[2:98]: $schema value \"https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#\" did not match any of the known ARM template deployment schemas.")]
+        [DataRow("NonWorking/keyvault-secret-reference.json", "[25:38]: Failed to convert parameter \"mySecret\": KeyVault secret references are not currently supported by the decompiler.")]
+        [DataRow("NonWorking/symbolic-names.json", "[27:16]: Decompilation of symbolic name templates is not currently supported")]
         public void Decompiler_raises_errors_for_unsupported_features(string resourcePath, string expectedMessage)
         {
             Action onDecompile = () => {

--- a/src/Bicep.Decompiler.IntegrationTests/NonWorking/keyvault-secret-reference.json
+++ b/src/Bicep.Decompiler.IntegrationTests/NonWorking/keyvault-secret-reference.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "keyvaultName": {
+            "type": "string"
+        },
+        "keyvaultSecret": {
+            "type": "string"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "dynamicSecret",
+            "properties": {
+                "mode": "Incremental",
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "parameters": {
+                    "mySecret": {
+                        "reference": {
+                            "keyVault": {
+                                "id": "[concat(resourceId('Microsoft.KeyVault/vaults', parameters('keyvaultName')))]"
+                            },
+                            "secretName": "[parameters('keyvaultSecret')]"
+                        }
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                        "mySecret": {
+                            "type": "string"
+                        }
+                    },
+                    "resources": [],
+                    "outputs": {}
+                }
+            }
+        }
+    ]
+}

--- a/src/Bicep.Decompiler.IntegrationTests/NonWorking/symbolic-names.json
+++ b/src/Bicep.Decompiler.IntegrationTests/NonWorking/symbolic-names.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "1.9-experimental",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "EXPERIMENTAL_WARNING": "Symbolic name support in ARM is experimental, and should be enabled for testing purposes only. Do not enable this setting for any production usage, or you may be unexpectedly broken at any time!",
+    "_generator": {
+      "name": "bicep",
+      "version": "dev",
+      "templateHash": "3810820475161539061"
+    }
+  },
+  "parameters": {
+    "storageAccountName": {
+      "type": "string"
+    },
+    "containerName": {
+      "type": "string",
+      "defaultValue": "logs"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]"
+    }
+  },
+  "functions": [],
+  "resources": {
+    "sa": {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2019-06-01",
+      "name": "[parameters('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    "container": {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2019-06-01",
+      "name": "[format('{0}/default/{1}', resourceInfo('sa').name, parameters('containerName'))]",
+      "dependsOn": [
+        "sa"
+      ]
+    }
+  }
+}

--- a/src/Bicep.Decompiler/TemplateConverter.cs
+++ b/src/Bicep.Decompiler/TemplateConverter.cs
@@ -1169,6 +1169,11 @@ namespace Bicep.Decompiler
             var paramProperties = new List<ObjectPropertySyntax>();
             foreach (var param in parameters)
             {
+                if (param.Value["reference"] is {} referenceValue)
+                {
+                    throw new ConversionFailedException($"Failed to convert parameter \"{param.Name}\": KeyVault secret references are not currently supported by the decompiler.", referenceValue);
+                }
+
                 paramProperties.Add(SyntaxFactory.CreateObjectProperty(param.Name, ParseJToken(param.Value["value"])));
             }
 
@@ -1452,6 +1457,11 @@ namespace Bicep.Decompiler
             if (targetScope != null)
             {
                 statements.Add(targetScope);
+            }
+
+            if (TemplateHelpers.GetProperty(template, "resources")?.Value is JObject resourcesObject)
+            {
+                throw new ConversionFailedException($"Decompilation of symbolic name templates is not currently supported", resourcesObject);
             }
 
             var parameters = (TemplateHelpers.GetProperty(template, "parameters")?.Value as JObject ?? new JObject()).Properties();

--- a/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
+++ b/src/Bicep.LangServer.IntegrationTests/CompletionTests.cs
@@ -1165,7 +1165,7 @@ module mod2 './|' = {}
                 var completionList = await client.RequestCompletion(new CompletionParams
                 {
                     TextDocument = new TextDocumentIdentifier(bicepFile.FileUri),
-                    Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor),
+                    Position = TextCoordinateConverter.GetPosition(bicepFile.LineStarts, cursor)
                 });
 
                 completions.Add(completionList);

--- a/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
+++ b/src/Bicep.LangServer/Handlers/BicepDefinitionHandler.cs
@@ -49,28 +49,24 @@ namespace Bicep.LanguageServer.Handlers
             {
                 return Task.FromResult(new LocationOrLocationLinks());
             }
+
             var result = this.symbolResolver.ResolveSymbol(request.TextDocument.Uri, request.Position);
+
             // No parent Symbol: ad hoc syntax matching
-            if (result is null)
+            return result switch
             {
-                return HandleUnboundSymbolLocationAsync(request, context);
-            }
-            // Declared symbols: go to definition
-            else if (result.Symbol is DeclaredSymbol declaration)
-            {
-                return HandleDeclaredDefinitionLocationAsync(request, result, declaration);
-            }
-            // Object property: currently only used for module param goto
-            else if (result.Origin is ObjectPropertySyntax objectPropertySyntax)
-            {
-                return HandleObjectPropertyLocationAsync(request, result, context);
-            }
-            // Used for module (name), variable or resource property access
-            else if (result.Symbol is PropertySymbol)
-            {
-                return HandlePropertyLocationAsync(request, result, context);
-            }
-            return Task.FromResult(new LocationOrLocationLinks()); 
+                null => HandleUnboundSymbolLocationAsync(request, context),
+
+                { Symbol: DeclaredSymbol declaration } => HandleDeclaredDefinitionLocationAsync(request, result, declaration),
+
+                // Object property: currently only used for module param goto
+                { Origin: ObjectPropertySyntax } => HandleObjectPropertyLocationAsync(request, result, context),
+
+                // Used for module (name), variable or resource property access
+                { Symbol: PropertySymbol } => HandlePropertyLocationAsync(request, result, context),
+
+                _ => Task.FromResult(new LocationOrLocationLinks()),
+            };
         }
 
         protected override DefinitionRegistrationOptions CreateRegistrationOptions(DefinitionCapability capability, ClientCapabilities clientCapabilities) => new()
@@ -89,7 +85,7 @@ namespace Bicep.LanguageServer.Handlers
                 (moduleSyntax, stringSyntax, token) => moduleSyntax.Path == stringSyntax && token.Type == TokenType.StringComplete)
                 && matchingNodes[^3] is ModuleDeclarationSyntax moduleDeclarationSyntax
                 && matchingNodes[^2] is StringSyntax stringToken
-                && context.Compilation.SourceFileGrouping.LookUpModuleSourceFile(moduleDeclarationSyntax) is ISourceFile sourceFile)
+                && context.Compilation.SourceFileGrouping.TryLookupModuleSourceFile(moduleDeclarationSyntax) is ISourceFile sourceFile)
             {
                 // goto beginning of the module file.
                 return GetModuleDefinitionLocationAsync(
@@ -138,42 +134,43 @@ namespace Bicep.LanguageServer.Handlers
 
         private Task<LocationOrLocationLinks> HandlePropertyLocationAsync(DefinitionParams request, SymbolResolutionResult result, CompilationContext context)
         {
-                var semanticModel = context.Compilation.GetEntrypointSemanticModel();
+            var semanticModel = context.Compilation.GetEntrypointSemanticModel();
 
-                // Find the underlying VariableSyntax being accessed
-                var syntax = result.Origin;
-                var propertyAccesses = new List<string>();
-                while (syntax is PropertyAccessSyntax propertyAccessSyntax)
+            // Find the underlying VariableSyntax being accessed
+            var syntax = result.Origin;
+            var propertyAccesses = new List<string>();
+            while (syntax is PropertyAccessSyntax propertyAccessSyntax)
+            {
+                // since we are traversing bottom up, add this access to the beginning of the list
+                propertyAccesses.Insert(0, propertyAccessSyntax.PropertyName.IdentifierName);
+                syntax = propertyAccessSyntax.BaseExpression;
+            }
+
+            if (syntax is VariableAccessSyntax ancestor
+                && semanticModel.GetSymbolInfo(ancestor) is DeclaredSymbol ancestorSymbol)
+            {
+                // If the symbol is a module, we need to redirect the user to the module file
+                // note: module.name doesn't follow this: it should refer to the declaration of the module in the current file, like regular variable and resource property accesses
+                if (propertyAccesses.Count == 2
+                && ancestorSymbol.DeclaringSyntax is ModuleDeclarationSyntax moduleDeclarationSyntax)
                 {
-                    // since we are traversing bottom up, add this access to the beginning of the list
-                    propertyAccesses.Insert(0, propertyAccessSyntax.PropertyName.IdentifierName);
-                    syntax = propertyAccessSyntax.BaseExpression;
+                    return GetModuleSymbolLocationAsync(result, context, moduleDeclarationSyntax, propertyAccesses[0], propertyAccesses[1]);
                 }
 
-                if (syntax is VariableAccessSyntax ancestor
-                    && semanticModel.GetSymbolInfo(ancestor) is DeclaredSymbol ancestorSymbol)
+                // Otherwise, we redirect user to the specified module, variable, or resource declaration
+                if (GetObjectSyntaxFromDeclaration(ancestorSymbol.DeclaringSyntax) is ObjectSyntax objectSyntax
+                    && ObjectSyntaxExtensions.SafeGetPropertyByNameRecursive(objectSyntax, propertyAccesses) is ObjectPropertySyntax resultingSyntax)
                 {
-                    // If the symbol is a module, we need to redirect the user to the module file
-                    // note: module.name doesn't follow this: it should refer to the declaration of the module in the current file, like regular variable and resource property accesses
-                    if (propertyAccesses.Count == 2
-                    && ancestorSymbol.DeclaringSyntax is ModuleDeclarationSyntax moduleDeclarationSyntax)
+                    return Task.FromResult(new LocationOrLocationLinks(new LocationOrLocationLink(new LocationLink
                     {
-                        return GetModuleSymbolLocationAsync(result, context, moduleDeclarationSyntax, propertyAccesses[0], propertyAccesses[1]);
-                    }
-
-                    // Otherwise, we redirect user to the specified module, variable, or resource declaration
-                    if (GetObjectSyntaxFromDeclaration(ancestorSymbol.DeclaringSyntax) is ObjectSyntax objectSyntax
-                        && ObjectSyntaxExtensions.SafeGetPropertyByNameRecursive(objectSyntax, propertyAccesses) is ObjectPropertySyntax resultingSyntax)
-                    {
-                        return Task.FromResult(new LocationOrLocationLinks(new LocationOrLocationLink(new LocationLink
-                        {
-                            OriginSelectionRange = result.Origin.ToRange(result.Context.LineStarts),
-                            TargetUri = request.TextDocument.Uri,
-                            TargetRange = resultingSyntax.ToRange(result.Context.LineStarts),
-                            TargetSelectionRange = resultingSyntax.ToRange(result.Context.LineStarts)
-                        })));
-                    }
+                        OriginSelectionRange = result.Origin.ToRange(result.Context.LineStarts),
+                        TargetUri = request.TextDocument.Uri,
+                        TargetRange = resultingSyntax.ToRange(result.Context.LineStarts),
+                        TargetSelectionRange = resultingSyntax.ToRange(result.Context.LineStarts)
+                    })));
                 }
+            }
+
             return Task.FromResult(new LocationOrLocationLinks());
         }
 


### PR DESCRIPTION
# Contributing a Pull Request

If you haven't already, read the full [contribution guide](../CONTRIBUTING.md). The guide may have changed since the last time you read it, so please double-check. Once you are done and ready to submit your PR, run through the relevant checklist below.

## Contributing to documentation

* [ ] The contribution does not exist in any of the docs in either the root of the [docs](../docs) directory or the [specs](../docs/spec)

## Contributing an example

We are integrating the Bicep examples into the [Azure QuickStart Templates](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md).  If you'd like to contribute new example `.bicep` files that showcase abilities of the language, please follow [these instructions](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) to add them directly there.  We can still take bug reports and fixes for the existing examples for the time being.

* [ ] This is a bug fix for an existing example
* [ ] I have resolved all warnings and errors shown by the Bicep VS Code extension
* [ ] I have checked that all tests are passing by running `dotnet test`
* [ ] I have consistent casing for all of my identifiers and am using camelCasing unless I have a justification to use another casing style

## Contributing a feature

* [ ] I have opened a new issue for the proposal, or commented on an existing one, and ensured that the Bicep maintainers are good with the design of the feature being implemented
* [ ] I have included "Fixes #{issue_number}" in the PR description, so GitHub can link to the issue and close it when the PR is merged
* [ ] I have appropriate test coverage of my new feature

## Contributing a snippet

* [ ] I have a snippet that is either a single, generic resource or multi resource that uses [parent-child syntax](https://github.com/Azure/bicep/blob/a22b9c80ba4f8b977f5d948f8bd8c54155ff6870/docs/spec/resource-scopes.md#parent-child-syntax)
* [ ] I have checked that there is not an equivalent snippet already submitted
* [ ] I have used camelCasing unless I have a justification to use another casing style
* [ ] I have placeholders values that correspond to their property names (e.g. `dnsPrefix: 'dnsPrefix'`), unless it's a property that MUST be changed or parameterized in order to deploy. In that case, I use 'REQUIRED' e.g. [keyData](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep#L26)
* [ ] I have my symbolic name as the first tab stop ($1) in the snippet. e.g. [res-aks-cluster.bicep](./src/Bicep.LangServer/Snippets/Templates/res-aks-cluster.bicep)
* [ ] I have a resource name property equal to "name"

  e.g.

  ```bicep
  resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-03-01' = {
    name: 'name'
  ```
